### PR TITLE
Improve validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21478,7 +21478,7 @@
     },
     "packages/components": {
       "name": "@monokle/components",
-      "version": "0.0.6",
+      "version": "0.0.11",
       "license": "MIT",
       "devDependencies": {
         "@ant-design/icons": "4.7.0",

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -45,7 +45,7 @@ export const validate = command<Options>({
 
     const validator = createDefaultMonokleValidator(parser);
     const config = await readConfig(configPath);
-    await validator.preload({ file: config });
+    await validator.preload(config);
 
     processRefs(resources, parser);
     const response = await validator.validate({ resources });

--- a/packages/validation/src/MonokleConfiguration.test.ts
+++ b/packages/validation/src/MonokleConfiguration.test.ts
@@ -14,24 +14,22 @@ it("should work with monokle.validation.yaml", async () => {
 
   // Step 2: Configure validator with monokle.validation.yaml
   await validator.preload({
-    file: {
-      // Responsible for validator construction
-      plugins: {
-        "open-policy-agent": true,
-        "yaml-syntax": true,
-        labels: false,
-        "kubernetes-schema": false,
-        "resource-links": false,
-      },
-      // Responsbility for rules
-      rules: {
-        KSV005: "warn",
-        "open-policy-agent/no-latest-image": "warn",
-      },
-      // Responsible for validator runtime behavior
-      settings: {
-        debug: true,
-      },
+    // Responsible for validator construction
+    plugins: {
+      "open-policy-agent": true,
+      "yaml-syntax": true,
+      labels: false,
+      "kubernetes-schema": false,
+      "resource-links": false,
+    },
+    // Responsbility for rules
+    rules: {
+      KSV005: "warn",
+      "open-policy-agent/no-latest-image": "warn",
+    },
+    // Responsible for validator runtime behavior
+    settings: {
+      debug: true,
     },
   });
 
@@ -56,56 +54,50 @@ it("should handle race conditions", async () => {
     const validator = createDefaultMonokleValidator();
 
     validator.preload({
-      args: {
-        plugins: {
-          "open-policy-agent": true,
-          "yaml-syntax": true,
-          labels: true,
-          "kubernetes-schema": true,
-          "resource-links": true,
-        },
-        rules: {
-          KSV005: false,
-          KSV013: true,
-        },
+      plugins: {
+        "open-policy-agent": true,
+        "yaml-syntax": true,
+        labels: true,
+        "kubernetes-schema": true,
+        "resource-links": true,
+      },
+      rules: {
+        KSV005: false,
+        KSV013: true,
       },
     });
 
     validator.preload({
-      args: {
-        plugins: {
-          "open-policy-agent": false,
-          "yaml-syntax": true,
-          labels: false,
-          "kubernetes-schema": false,
-          "resource-links": false,
-        },
-        rules: {
-          KSV005: false,
-          KSV013: true,
-        },
+      plugins: {
+        "open-policy-agent": false,
+        "yaml-syntax": true,
+        labels: false,
+        "kubernetes-schema": false,
+        "resource-links": false,
+      },
+      rules: {
+        KSV005: false,
+        KSV013: true,
       },
     });
 
     validator.preload({
-      file: {
-        // Responsible for validator construction
-        plugins: {
-          "open-policy-agent": true,
-          "yaml-syntax": false,
-          labels: false,
-          "kubernetes-schema": false,
-          "resource-links": false,
-        },
-        // Responsbility for rules
-        rules: {
-          KSV005: "warn",
-          "open-policy-agent/no-latest-image": "warn",
-        },
-        // Responsible for validator runtime behavior
-        settings: {
-          debug: true,
-        },
+      // Responsible for validator construction
+      plugins: {
+        "open-policy-agent": true,
+        "yaml-syntax": false,
+        labels: false,
+        "kubernetes-schema": false,
+        "resource-links": false,
+      },
+      // Responsbility for rules
+      rules: {
+        KSV005: "warn",
+        "open-policy-agent/no-latest-image": "warn",
+      },
+      // Responsible for validator runtime behavior
+      settings: {
+        debug: true,
       },
     });
 

--- a/packages/validation/src/MonokleValidator.test.ts
+++ b/packages/validation/src/MonokleValidator.test.ts
@@ -32,11 +32,11 @@ it("should be abort properly", async () => {
     processRefs(RESOURCES, parser);
     const validating = validator.validate({ resources: RESOURCES });
 
-    validator.configureArgs({
+    validator.config = {
       plugins: {
         "kubernetes-schema": false,
       },
-    });
+    };
 
     await validating;
 
@@ -98,20 +98,18 @@ it("should be valid SARIF", async () => {
 
 function configureValidator(validator: MonokleValidator) {
   return validator.preload({
-    file: {
-      plugins: {
-        labels: true,
-        "yaml-syntax": true,
-        "resource-links": true,
-        "kubernetes-schema": true,
-        "open-policy-agent": true,
+    plugins: {
+      labels: true,
+      "yaml-syntax": true,
+      "resource-links": true,
+      "kubernetes-schema": true,
+      "open-policy-agent": true,
+    },
+    settings: {
+      "kubernetes-schema": {
+        schemaVersion: "1.24.2",
       },
-      settings: {
-        "kubernetes-schema": {
-          schemaVersion: "1.24.2",
-        },
-        debug: true,
-      },
+      debug: true,
     },
   });
 }

--- a/packages/validation/src/common/AbstractPlugin.ts
+++ b/packages/validation/src/common/AbstractPlugin.ts
@@ -162,10 +162,6 @@ export abstract class AbstractPlugin implements Plugin {
     return Promise.resolve();
   }
 
-  async clear() {
-    this._previous = [];
-  }
-
   async validate(
     resources: Resource[],
     incremental?: Incremental
@@ -229,5 +225,13 @@ export abstract class AbstractPlugin implements Plugin {
     }
 
     return results;
+  }
+
+  async clear() {
+    this._previous = [];
+  }
+
+  async unload() {
+    return;
   }
 }

--- a/packages/validation/src/common/AbstractPlugin.ts
+++ b/packages/validation/src/common/AbstractPlugin.ts
@@ -117,7 +117,7 @@ export abstract class AbstractPlugin implements Plugin {
     settings?: JsonObject;
   }): Promise<void> {
     this.configureRules(config.rules);
-    await this.configureValidator(config.settings);
+    await this.configurePlugin(config.settings);
     this.configured = true;
   }
 
@@ -158,9 +158,7 @@ export abstract class AbstractPlugin implements Plugin {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected configureValidator(
-    settings: JsonObject | undefined
-  ): Promise<void> {
+  protected configurePlugin(settings: JsonObject | undefined): Promise<void> {
     return Promise.resolve();
   }
 

--- a/packages/validation/src/common/types.ts
+++ b/packages/validation/src/common/types.ts
@@ -105,16 +105,84 @@ export type Incremental = {
   resourceIds: string[];
 };
 
-export interface ValidatorConstructor {
-  new (parser: ResourceParser): Validator;
+export interface PluginConstructor {
+  new (parser: ResourceParser): Plugin;
 }
 
-export interface Validator {
+export type PluginMetadata = {
+  /**
+   * The identifier of this plugin.
+   *
+   * @remark This is the prefix of all rule identifiers.
+   * @example "KSV"
+   */
+  id: string;
+
+  /**
+   * The name of this plugin
+   *
+   * @example "open-policy-agent"
+   */
+  name: string;
+
+  /**
+   * The display name of this plugin
+   *
+   * @example "Open Policy Agent
+   */
+  displayName: string;
+
+  /**
+   * The description of this plugin.
+   */
+  description: string;
+
+  /**
+   * The icon of this plugin
+   */
+  icon?: string;
+
+  /**
+   * The website of this plugin.
+   */
+  learnMoreUrl?: string;
+};
+
+export interface Plugin {
+  /**
+   * The name of this plugin.
+   *
+   * @deprecated use metadata.name.
+   */
   get name(): string;
+
+  /**
+   * The metadata of the plugin.
+   */
+  get metadata(): PluginMetadata;
+
+  /**
+   * The rules of this plugin.
+   */
   get rules(): ValidationRule[];
+
   get enabled(): boolean;
   set enabled(value: boolean);
 
+  /**
+   * Whether the rule exists in this plugin.
+   *
+   * @rule Either the rule identifier or display name.
+   * @example "KSV013" or "open-policy-agent/no-latest-image"
+   */
+  hasRule(rule: string): boolean;
+
+  /**
+   * Whether the rule is enabled in this plugin.
+   *
+   * @rule Either the rule identifier or display name.
+   * @example "KSV013" or "open-policy-agent/no-latest-image"
+   */
   isRuleEnabled(rule: string): boolean;
 
   configure(config: { rules?: RuleMap; settings?: JsonObject }): Promise<void>;

--- a/packages/validation/src/common/types.ts
+++ b/packages/validation/src/common/types.ts
@@ -193,4 +193,5 @@ export interface Plugin {
   ): Promise<ValidationRun>;
 
   clear(): Promise<void>;
+  unload(): Promise<void>;
 }

--- a/packages/validation/src/utils/abort.ts
+++ b/packages/validation/src/utils/abort.ts
@@ -11,12 +11,17 @@ export class AbortError extends ExtendableError {
   }
 }
 
-export function throwIfAborted(signal: AbortSignal) {
+/**
+ * Throws an AbortError if any signal is aborted.
+ */
+export function throwIfAborted(...signals: (AbortSignal | undefined)[]) {
   // AbortSignal.throwIfAborted exists but is not supported in NodeJs <v17.3.0
   // and it is also not available in abort-controller polyfill.
   // See https://nodejs.org/api/globals.html#abortsignalthrowifaborted
-  if (signal.aborted) {
-    throw new AbortError(signal.reason);
+  for (const signal of signals) {
+    if (signal && signal.aborted) {
+      throw new AbortError(signal.reason);
+    }
   }
 }
 

--- a/packages/validation/src/validators/kubernetes-schema/validator.ts
+++ b/packages/validation/src/validators/kubernetes-schema/validator.ts
@@ -2,7 +2,7 @@ import Ajv, { ErrorObject, ValidateFunction } from "ajv";
 import { JsonObject } from "type-fest";
 import { Document, isCollection, ParsedNode } from "yaml";
 import { z } from "zod";
-import { AbstractPlugin } from "../../common/AbstractValidator.js";
+import { AbstractPlugin } from "../../common/AbstractPlugin.js";
 import { ResourceParser } from "../../common/resourceParser.js";
 import { ValidationResult } from "../../common/sarif.js";
 import { Incremental, Resource } from "../../common/types.js";
@@ -44,7 +44,7 @@ export class KubernetesSchemaValidator extends AbstractPlugin {
     );
   }
 
-  protected override async configureValidator(
+  protected override async configurePlugin(
     rawSettings: JsonObject = {}
   ): Promise<void> {
     this._settings = Settings.parse(rawSettings["kubernetes-schema"] ?? {});

--- a/packages/validation/src/validators/kubernetes-schema/validator.ts
+++ b/packages/validation/src/validators/kubernetes-schema/validator.ts
@@ -2,7 +2,7 @@ import Ajv, { ErrorObject, ValidateFunction } from "ajv";
 import { JsonObject } from "type-fest";
 import { Document, isCollection, ParsedNode } from "yaml";
 import { z } from "zod";
-import { AbstractValidator } from "../../common/AbstractValidator.js";
+import { AbstractPlugin } from "../../common/AbstractValidator.js";
 import { ResourceParser } from "../../common/resourceParser.js";
 import { ValidationResult } from "../../common/sarif.js";
 import { Incremental, Resource } from "../../common/types.js";
@@ -22,9 +22,7 @@ const Settings = z.object({
   schemaVersion: z.string().default("1.24.2"),
 });
 
-export class KubernetesSchemaValidator extends AbstractValidator {
-  static toolName = "kubernetes-schema";
-
+export class KubernetesSchemaValidator extends AbstractPlugin {
   private _settings!: Settings;
   private ajv!: Ajv.Ajv;
 
@@ -32,7 +30,18 @@ export class KubernetesSchemaValidator extends AbstractValidator {
     private resourceParser: ResourceParser,
     private schemaLoader: SchemaLoader
   ) {
-    super(KubernetesSchemaValidator.toolName, KUBERNETES_SCHEMA_RULES);
+    super(
+      {
+        id: "K8S",
+        name: "kubernetes-schema",
+        displayName: "Kubernetes Schema",
+        description:
+          "Validates that your manifests are well-defined in the schema for their resource kind/version.",
+        icon: "k8s-schema",
+        learnMoreUrl: "https://kubeshop.github.io/monokle/resource-validation/",
+      },
+      KUBERNETES_SCHEMA_RULES
+    );
   }
 
   protected override async configureValidator(

--- a/packages/validation/src/validators/labels/validator.ts
+++ b/packages/validation/src/validators/labels/validator.ts
@@ -1,5 +1,5 @@
 import { YAMLMap } from "yaml";
-import { AbstractPlugin } from "../../common/AbstractValidator.js";
+import { AbstractPlugin } from "../../common/AbstractPlugin.js";
 import { ResourceParser } from "../../common/resourceParser.js";
 import { ValidationResult } from "../../common/sarif.js";
 import { Incremental, Resource } from "../../common/types.js";

--- a/packages/validation/src/validators/labels/validator.ts
+++ b/packages/validation/src/validators/labels/validator.ts
@@ -1,5 +1,5 @@
 import { YAMLMap } from "yaml";
-import { AbstractValidator } from "../../common/AbstractValidator.js";
+import { AbstractPlugin } from "../../common/AbstractValidator.js";
 import { ResourceParser } from "../../common/resourceParser.js";
 import { ValidationResult } from "../../common/sarif.js";
 import { Incremental, Resource } from "../../common/types.js";
@@ -10,11 +10,20 @@ import { LABELS_RULES } from "./rules.js";
 /**
  * Trivial validator used for development and testing.
  */
-export class LabelsValidator extends AbstractValidator {
-  static toolName = "labels";
-
+export class LabelsValidator extends AbstractPlugin {
   constructor(private parser: ResourceParser) {
-    super(LabelsValidator.toolName, LABELS_RULES);
+    super(
+      {
+        id: "LBL",
+        name: "labels",
+        displayName: "Label validator",
+        description:
+          "Validates whether your manifests have labels. This is a trivial validator used for development and testing.",
+        icon: "k8s-schema",
+        learnMoreUrl: "https://kubeshop.github.io/monokle/resource-validation/",
+      },
+      LABELS_RULES
+    );
   }
 
   async doValidate(

--- a/packages/validation/src/validators/open-policy-agent/rules.ts
+++ b/packages/validation/src/validators/open-policy-agent/rules.ts
@@ -27,7 +27,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         problem: {
           severity: "warning",
         },
-        severity: "medium",
+        "security-severity": 5,
         entrypoint: "appshield/kubernetes/KSV001/deny",
         path: "$container.securityContext.allowPrivilegeEscalation",
       },
@@ -50,7 +50,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         problem: {
           severity: "warning",
         },
-        severity: "medium",
+        "security-severity": 5,
         entrypoint: "appshield/kubernetes/KSV002/deny",
         path: "$container.AppArmor",
       },
@@ -70,7 +70,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Add 'ALL' to containers[].securityContext.capabilities.drop.",
       },
       properties: {
-        severity: "low",
+        "security-severity": 2,
         entrypoint: "appshield/kubernetes/KSV003/deny",
         path: "$container.securityContext.capabilities.drop",
       },
@@ -90,7 +90,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Remove the SYS_ADMIN capability from 'containers[].securityContext.capabilities.add'.",
       },
       properties: {
-        severity: "high",
+        "security-severity": 8,
         entrypoint: "appshield/kubernetes/KSV005/deny",
         path: "$container.securityContext.capabilities.add",
       },
@@ -110,7 +110,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Do not specify `/var/run/docker.sock` in spec.template.volumes.hostPath.path.",
       },
       properties: {
-        severity: "high",
+        "security-severity": 8,
         entrypoint: "appshield/kubernetes/KSV006/deny",
         path: "spec.template.spec.volumes.hostPath.path",
       },
@@ -130,7 +130,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Do not set 'spec.template.spec.hostIPC' to true.",
       },
       properties: {
-        severity: "high",
+        "security-severity": 8,
         entrypoint: "appshield/kubernetes/KSV008/deny",
         path: "spec.template.spec.hostIPC",
       },
@@ -150,7 +150,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Do not set 'spec.template.spec.hostNetwork' to true.",
       },
       properties: {
-        severity: "high",
+        "security-severity": 8,
         entrypoint: "appshield/kubernetes/KSV009/deny",
         path: "spec.template.spec.hostNetwork",
       },
@@ -170,7 +170,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Do not set 'spec.template.spec.hostPID' to true.",
       },
       properties: {
-        severity: "high",
+        "security-severity": 8,
         entrypoint: "appshield/kubernetes/KSV010/deny",
         path: "spec.template.spec.hostPID",
       },
@@ -190,7 +190,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Add a cpu limitation to 'spec.resources.limits.cpu'.",
       },
       properties: {
-        severity: "low",
+        "security-severity": 2,
         entrypoint: "appshield/kubernetes/KSV011/deny",
         path: "$container.resources.limits.cpu",
       },
@@ -210,7 +210,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Set 'containers[].securityContext.runAsNonRoot' to true.",
       },
       properties: {
-        severity: "medium",
+        "security-severity": 5,
         entrypoint: "appshield/kubernetes/KSV012/deny",
         path: "$container.securityContext.runAsNonRoot",
       },
@@ -230,7 +230,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Use a specific container image tag that is not 'latest'.",
       },
       properties: {
-        severity: "low",
+        "security-severity": 2,
         entrypoint: "appshield/kubernetes/KSV013/deny",
         path: "$container.image",
       },
@@ -250,7 +250,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Change 'containers[].securityContext.readOnlyRootFilesystem' to 'true'.",
       },
       properties: {
-        severity: "low",
+        "security-severity": 2,
         entrypoint: "appshield/kubernetes/KSV014/deny",
         path: "$container.securityContext.readOnlyRootFilesystem",
       },
@@ -270,7 +270,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Set 'containers[].resources.requests.cpu'.",
       },
       properties: {
-        severity: "low",
+        "security-severity": 2,
         entrypoint: "appshield/kubernetes/KSV015/deny",
         path: "$container.resources.requests.cpu",
       },
@@ -289,7 +289,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Set 'containers[].resources.requests.memory'.",
       },
       properties: {
-        severity: "low",
+        "security-severity": 2,
         entrypoint: "appshield/kubernetes/KSV016/deny",
         path: "$container.resources.requests.memory",
       },
@@ -309,7 +309,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Change 'containers[].securityContext.privileged' to false",
       },
       properties: {
-        severity: "high",
+        "security-severity": 8,
         entrypoint: "appshield/kubernetes/KSV017/deny",
         path: "$container.securityContext.privileged",
       },
@@ -328,7 +328,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Set a limit value under 'containers[].resources.limits.memory'.",
       },
       properties: {
-        severity: "low",
+        "security-severity": 2,
         entrypoint: "appshield/kubernetes/KSV018/deny",
         path: "$container.resources.limits.memory",
       },
@@ -348,7 +348,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Set 'containers[].securityContext.runAsUser' to an integer > 10000.",
       },
       properties: {
-        severity: "low",
+        "security-severity": 2,
         entrypoint: "appshield/kubernetes/KSV020/deny",
         path: "$container.securityContext.runAsUser",
       },
@@ -368,7 +368,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Set 'containers[].securityContext.runAsGroup' to an integer > 10000.",
       },
       properties: {
-        severity: "medium",
+        "security-severity": 5,
         entrypoint: "appshield/kubernetes/KSV021/deny",
         path: "$container.securityContext.runAsGroup",
       },
@@ -388,7 +388,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Do not set 'spec.volumes[*].hostPath'.",
       },
       properties: {
-        severity: "medium",
+        "security-severity": 5,
         entrypoint: "appshield/kubernetes/KSV023/deny",
         path: "spec.template.spec.volumes.hostPath",
       },
@@ -408,7 +408,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Do not set spec.containers[*].ports[*].hostPort and spec.initContainers[*].ports[*].hostPort.",
       },
       properties: {
-        severity: "high",
+        "security-severity": 8,
         entrypoint: "appshield/kubernetes/KSV024/deny",
         path: "$container.ports",
       },
@@ -428,7 +428,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Do not set spec.securityContext.seLinuxOptions, spec.containers[*].securityContext.seLinuxOptions and spec.initContainers[*].securityContext.seLinuxOptions.",
       },
       properties: {
-        severity: "medium",
+        "security-severity": 5,
         entrypoint: "appshield/kubernetes/KSV025/deny",
         path: "$container.securityContext.seLinuxOptions",
       },
@@ -448,7 +448,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Do not set spec.containers[*].securityContext.procMount and spec.initContainers[*].securityContext.procMount.",
       },
       properties: {
-        severity: "medium",
+        "security-severity": 5,
         entrypoint: "appshield/kubernetes/KSV027/deny",
         path: "$container.securityContext.procMount",
       },
@@ -468,7 +468,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Do not Set 'spec.volumes[*]' to any of the disallowed volume types.",
       },
       properties: {
-        severity: "low",
+        "security-severity": 2,
         entrypoint: "appshield/kubernetes/KSV028/deny",
         path: "spec.template.spec.volumes",
       },
@@ -488,7 +488,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "containers[].securityContext.runAsGroup' to a non-zero integer or leave undefined.",
       },
       properties: {
-        severity: "low",
+        "security-severity": 2,
         entrypoint: "appshield/kubernetes/KSV029/deny",
         path: "$container.securityContext.runAsGroup",
       },
@@ -508,7 +508,7 @@ export const DEFAULT_TRIVY_PLUGIN: PolicyMetadata = {
         text: "Set 'spec.securityContext.seccompProfile.type', 'spec.containers[*].securityContext.seccompProfile' and 'spec.initContainers[*].securityContext.seccompProfile' to 'RuntimeDefault' or undefined.",
       },
       properties: {
-        severity: "low",
+        "security-severity": 2,
         entrypoint: "appshield/kubernetes/KSV030/deny",
         path: "$container.securityContext.seccompProfile.type",
       },

--- a/packages/validation/src/validators/open-policy-agent/types.ts
+++ b/packages/validation/src/validators/open-policy-agent/types.ts
@@ -25,10 +25,6 @@ export type PolicyMetadata = {
  * These are a rule's custom properties used by the OPA validator.
  */
 export type OpaProperties = {
-  /**
-   * @deprecated use properties.problem.severity instead.
-   */
-  severity: "low" | "medium" | "high";
   entrypoint: string;
   path: string;
 };

--- a/packages/validation/src/validators/open-policy-agent/validator.ts
+++ b/packages/validation/src/validators/open-policy-agent/validator.ts
@@ -6,7 +6,7 @@ import get from "lodash/get.js";
 import invariant from "tiny-invariant";
 import { JsonObject } from "type-fest";
 import { z } from "zod";
-import { AbstractValidator } from "../../common/AbstractValidator.js";
+import { AbstractPlugin } from "../../common/AbstractValidator.js";
 import { ResourceParser } from "../../common/resourceParser.js";
 import {
   Region,
@@ -38,7 +38,7 @@ const CONTROLLER_KINDS = [
 
 type YamlPath = Array<string | number>;
 
-export class OpenPolicyAgentValidator extends AbstractValidator {
+export class OpenPolicyAgentValidator extends AbstractPlugin {
   static toolName = "open-policy-agent";
 
   private _settings!: Settings;
@@ -48,7 +48,18 @@ export class OpenPolicyAgentValidator extends AbstractValidator {
     private resourceParser: ResourceParser,
     private wasmLoader: WasmLoader
   ) {
-    super(OpenPolicyAgentValidator.toolName, OPEN_POLICY_AGENT_RULES);
+    super(
+      {
+        id: "KSV",
+        name: "open-policy-agent",
+        displayName: "Open Policy Agent",
+        description:
+        "Open Policy Agent Policy-based control. Flexible, fine-grained control for administrators across the stack.",
+        icon: "open-policy-agent",
+        learnMoreUrl: "https://github.com/open-policy-agent/opa",
+      },
+      OPEN_POLICY_AGENT_RULES
+    );
   }
 
   override async configureValidator(settings: JsonObject = {}): Promise<void> {

--- a/packages/validation/src/validators/open-policy-agent/validator.ts
+++ b/packages/validation/src/validators/open-policy-agent/validator.ts
@@ -6,7 +6,7 @@ import get from "lodash/get.js";
 import invariant from "tiny-invariant";
 import { JsonObject } from "type-fest";
 import { z } from "zod";
-import { AbstractPlugin } from "../../common/AbstractValidator.js";
+import { AbstractPlugin } from "../../common/AbstractPlugin.js";
 import { ResourceParser } from "../../common/resourceParser.js";
 import {
   Region,
@@ -62,7 +62,7 @@ export class OpenPolicyAgentValidator extends AbstractPlugin {
     );
   }
 
-  override async configureValidator(settings: JsonObject = {}): Promise<void> {
+  override async configurePlugin(settings: JsonObject = {}): Promise<void> {
     this._settings = Settings.parse(settings["open-policy-agent"] ?? {});
     const wasmSrc = this._settings.wasmSrc;
     const wasm = await this.wasmLoader.load(wasmSrc);

--- a/packages/validation/src/validators/resource-links/validator.ts
+++ b/packages/validation/src/validators/resource-links/validator.ts
@@ -1,4 +1,4 @@
-import { AbstractPlugin } from "../../common/AbstractValidator.js";
+import { AbstractPlugin } from "../../common/AbstractPlugin.js";
 import { ValidationResult, Region } from "../../common/sarif.js";
 import {
   Resource,

--- a/packages/validation/src/validators/resource-links/validator.ts
+++ b/packages/validation/src/validators/resource-links/validator.ts
@@ -1,4 +1,4 @@
-import { AbstractValidator } from "../../common/AbstractValidator.js";
+import { AbstractPlugin } from "../../common/AbstractValidator.js";
 import { ValidationResult, Region } from "../../common/sarif.js";
 import {
   Resource,
@@ -17,11 +17,19 @@ export type ResourceLinksValidatorConfig = ToolConfig<"resource-links">;
  *
  * @prerequisite you MUST run `processRefs` before calling the validator.
  */
-export class ResourceLinksValidator extends AbstractValidator {
-  static toolName = "resource-links";
-
+export class ResourceLinksValidator extends AbstractPlugin {
   constructor() {
-    super(ResourceLinksValidator.toolName, RESOURCE_LINK_RULES);
+    super(
+      {
+        id: "LNK",
+        name: "resource-links",
+        displayName: "Resource Links",
+        description: "Validates that references to other resources are valid.",
+        icon: "resource-links",
+        learnMoreUrl: "https://kubeshop.github.io/monokle/resource-validation/",
+      },
+      RESOURCE_LINK_RULES
+    );
   }
 
   override merge(

--- a/packages/validation/src/validators/yaml-syntax/validator.ts
+++ b/packages/validation/src/validators/yaml-syntax/validator.ts
@@ -1,17 +1,25 @@
 import { YAMLError } from "yaml";
-import { AbstractValidator } from "../../common/AbstractValidator.js";
+import { AbstractPlugin } from "../../common/AbstractValidator.js";
 import { ResourceParser } from "../../common/resourceParser.js";
 import { ValidationResult } from "../../common/sarif.js";
-import { Incremental, Resource, ToolConfig } from "../../common/types.js";
+import { Incremental, Resource } from "../../common/types.js";
 import { createLocations } from "../../utils/createLocations.js";
 import { isDefined } from "../../utils/isDefined.js";
 import { YAML_RULES, YAML_RULE_MAP } from "./rules.js";
 
-export class YamlValidator extends AbstractValidator {
-  static toolName = "yaml-syntax";
-
+export class YamlValidator extends AbstractPlugin {
   constructor(private resourceParser: ResourceParser) {
-    super(YamlValidator.toolName, YAML_RULES);
+    super(
+      {
+        id: "YML",
+        name: "yaml-syntax",
+        icon: "yaml-syntax",
+        displayName: "YAML Syntax",
+        description: "Validates that your manifests have correct YAML syntax.",
+        learnMoreUrl: "https://kubeshop.github.io/monokle/resource-validation/",
+      },
+      YAML_RULES
+    );
   }
 
   async doValidate(

--- a/packages/validation/src/validators/yaml-syntax/validator.ts
+++ b/packages/validation/src/validators/yaml-syntax/validator.ts
@@ -1,5 +1,5 @@
 import { YAMLError } from "yaml";
-import { AbstractPlugin } from "../../common/AbstractValidator.js";
+import { AbstractPlugin } from "../../common/AbstractPlugin.js";
 import { ResourceParser } from "../../common/resourceParser.js";
 import { ValidationResult } from "../../common/sarif.js";
 import { Incremental, Resource } from "../../common/types.js";


### PR DESCRIPTION
This PR improves validator:

- It fixes isPluginEnabled/isRuleEnabled and looks now at the actual validator state instead of config object.
- It embeds the validation metadata. We use this within the UI to show the validation configuration.
- It simplifies configuration (no more args and file - it was too complex and unneeded).
- It reworks the way plugins are loaded.

**Loading plugins**

A plugin will now be loaded no matter whether it is enabled or disabled. If you put it within the plugin object, we will load it. You can now after loading use the metadata to show the UI. You can still use the boolean to enable/disable it. When you remove the feature from the plugin object we will unload the validator.