### PR TITLE
feat: PaneCloseIcon atom

### DIFF
--- a/packages/components/src/atoms/PaneCloseIcon/PaneCloseIcon.stories.tsx
+++ b/packages/components/src/atoms/PaneCloseIcon/PaneCloseIcon.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import PaneCloseIcon from "./PaneCloseIcon";
+
+export default {
+  title: "Atoms/PaneCloseIcon",
+  component: PaneCloseIcon,
+} as ComponentMeta<typeof PaneCloseIcon>;
+
+const Template: ComponentStory<typeof PaneCloseIcon> = (args) => <PaneCloseIcon {...args} />;
+
+export const DefaultComponent = Template.bind({});
+DefaultComponent.args = {
+  containerStyle: {
+    backgroundColor: "red",
+  },
+  onClick: () => {},
+};

--- a/packages/components/src/atoms/PaneCloseIcon/PaneCloseIcon.styled.tsx
+++ b/packages/components/src/atoms/PaneCloseIcon/PaneCloseIcon.styled.tsx
@@ -1,0 +1,20 @@
+import Colors from "@/styles/Colors";
+import styled from "styled-components";
+
+import { DoubleLeftOutlined as RawDoubleLeftOutlined } from "@ant-design/icons";
+
+export const DoubleLeftOutlined = styled(RawDoubleLeftOutlined)`
+  font-size: 12px;
+  color: ${Colors.grey2};
+`;
+
+export const PaneCloseIconContainer = styled.div`
+  background-color: ${Colors.whitePure};
+  border-radius: 50%;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+`;

--- a/packages/components/src/atoms/PaneCloseIcon/PaneCloseIcon.tsx
+++ b/packages/components/src/atoms/PaneCloseIcon/PaneCloseIcon.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import * as S from "./PaneCloseIcon.styled";
+
+export type PaneCloseIconType = {
+  onClick: () => void;
+  containerId?: string;
+  containerStyle?: React.CSSProperties;
+  iconStyle?: React.CSSProperties;
+};
+
+const PaneCloseIcon: React.FC<PaneCloseIconType> = (props) => {
+  const { containerId = "pane-close", containerStyle = {}, iconStyle = {}, onClick } = props;
+
+  return (
+    <S.PaneCloseIconContainer id={containerId} style={{ ...containerStyle }} onClick={onClick}>
+      <S.DoubleLeftOutlined style={{ ...iconStyle }} />
+    </S.PaneCloseIconContainer>
+  );
+};
+
+export default PaneCloseIcon;

--- a/packages/components/src/atoms/PaneCloseIcon/index.ts
+++ b/packages/components/src/atoms/PaneCloseIcon/index.ts
@@ -1,0 +1,1 @@
+export * from "./PaneCloseIcon";

--- a/packages/components/src/atoms/index.ts
+++ b/packages/components/src/atoms/index.ts
@@ -2,3 +2,4 @@ export * from "./CopyButton";
 export * from "./Dots";
 export * from "./Icon";
 export * from "./Spinner";
+export * from "./PaneCloseIcon";

--- a/packages/components/src/styles/Colors.ts
+++ b/packages/components/src/styles/Colors.ts
@@ -22,6 +22,7 @@ enum Colors {
   grey4 = "#303030", // gray, gray 4
   grey3b = "#293235",
   grey3 = "#262626", // gray, gray 3
+  grey2 = "#1D1D1D",
   grey1 = "#141414", // gray, gray 1
 
   coldGrey = "#31393C",


### PR DESCRIPTION
## Changes

- `PaneCloseIcon` used mainly for closing the left pane

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
