### PR TITLE
fix: make walkthrough modal height match the designs

### DIFF
--- a/.changeset/two-taxis-refuse.md
+++ b/.changeset/two-taxis-refuse.md
@@ -1,0 +1,5 @@
+---
+"@monokle/components": patch
+---
+
+adjest the modal height to match the designs

--- a/packages/components/src/molecules/WalkThrough/WalkThroughCard.styles.tsx
+++ b/packages/components/src/molecules/WalkThrough/WalkThroughCard.styles.tsx
@@ -9,7 +9,7 @@ export const Container = styled.div`
   gap: 64px;
   padding: 24px 32px 32px 32px;
 
-  height: 450px;
+  height: 402px;
 `;
 
 export const CardMedia = styled.div`


### PR DESCRIPTION
This PR tweaks the styles to get the walkthrough height the same as the designs.

## Changes

-

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
