### PR TITLE
chore: exclude peer dependencies from bundle

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -67,6 +67,8 @@
     "use-debounced-effect": "2.0.1"
   },
   "peerDependencies": {
+    "@monokle/validation": "*",
+    "antd": "^4.0.0",
     "react": "^18.0 || ^17.0 || ^16.0",
     "react-dom": "^18.0 || ^17.0 || ^16.0",
     "styled-components": "^5.0.0",

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -22,12 +22,15 @@ export default defineConfig({
       fileName: (format) => `lib.${format}.js`,
     },
     rollupOptions: {
-      external: ["react", "react-dom", "styled-components"],
+      external: ["react", "react-dom", "styled-components", "framer-motion", "antd", "@monokle/validation"],
       output: {
         globals: {
           react: "React",
           "react-dom": "ReactDOM",
           "styled-components": "styled",
+          "framer-motion": "framer",
+          antd: "antd",
+          "@monokle/validation": "monokle-validation",
         },
       },
     },


### PR DESCRIPTION
This PR externalises antd, framer-motion, and monkle/validation

## Changes

-

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
