### PR TITLE
fix: fix argo build

### DIFF
--- a/.changeset/warm-dingos-dream.md
+++ b/.changeset/warm-dingos-dream.md
@@ -1,0 +1,5 @@
+---
+"@monokle/validation": patch
+---
+
+Fix argo build

--- a/packages/validation/src/createExtensibleMonokleValidator.browser.ts
+++ b/packages/validation/src/createExtensibleMonokleValidator.browser.ts
@@ -36,7 +36,7 @@ export function createExtensibleMonokleValidator(
       default:
         try {
           const url = `https://plugins.monokle.com/validation/${pluginName}/latest.js`;
-          const customPlugin = await import(/* @vite-ignore */ `${url}`);
+          const customPlugin = await import(/* @vite-ignore */ url);
           return new SimpleCustomValidator(customPlugin.default, parser);
         } catch (err) {
           throw new Error(

--- a/packages/validation/src/validators/custom/devValidator.ts
+++ b/packages/validation/src/validators/custom/devValidator.ts
@@ -69,7 +69,7 @@ export class DevCustomValidator implements Plugin {
         this._currentHash = bundle.hash;
         const encodedSource = btoa(bundle.code);
         const dataUrl = `data:text/javascript;base64,${encodedSource}`;
-        import(/* @vite-ignore */ `${dataUrl}`).then((module) => {
+        import(/* @vite-ignore */ dataUrl).then((module) => {
           const pluginInit = module.default;
           const validator = new SimpleCustomValidator(pluginInit, this.parser);
           this._currentValidator = validator;


### PR DESCRIPTION
This PR fixes argo build. Using a literal string like this was a recommendation to get rid of `Webpack - Critical dependency: the request of a dependency is an expression`. However, a subtle side-effect is that WebPack will now bundle every file in the library, including NodeJs specific files which should've been excluded because they have a different entrypoint.

The result is that the build fails because the browser is incompatible with these NodeJs variants that rely on NodeJs standard libraries which are unavailable in the browser. Removing the string literal to a string variable will surprisingly remove this subtle effect and the build appear to succeed in first tests which were done through package linking.