### PR TITLE
chore: version bump monaco-kubernetes

### DIFF
--- a/.changeset/strong-walls-cross.md
+++ b/.changeset/strong-walls-cross.md
@@ -1,0 +1,5 @@
+---
+"monaco-kubernetes": patch
+---
+
+update monaco-kubernetes

--- a/package-lock.json
+++ b/package-lock.json
@@ -23492,10 +23492,6 @@
         "globrex": "^0.1.2"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.2.0",
-      "license": "MIT"
-    },
     "node_modules/tinybench": {
       "version": "2.4.0",
       "dev": true,
@@ -26225,7 +26221,7 @@
       "devDependencies": {
         "@ant-design/icons": "4.7.0",
         "@babel/core": "7.17.8",
-        "@monokle/validation": "0.15.0",
+        "@monokle/validation": "0.15.1",
         "@rjsf/antd": "5.0.0-beta.11",
         "@storybook/addon-actions": "6.5.16",
         "@storybook/addon-essentials": "6.5.16",
@@ -26308,10 +26304,10 @@
       "license": "MIT"
     },
     "packages/monaco-kubernetes": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@monokle/validation": "^0.15.0",
+        "@monokle/validation": "^0.15.1",
         "@types/json-schema": "^7.0.0",
         "jsonc-parser": "^3.0.0",
         "monaco-marker-data-provider": "^1.0.0",
@@ -26928,7 +26924,7 @@
     },
     "packages/validation": {
       "name": "@monokle/validation",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@open-policy-agent/opa-wasm": "1.8.0",
@@ -29535,7 +29531,7 @@
       "requires": {
         "@ant-design/icons": "4.7.0",
         "@babel/core": "7.17.8",
-        "@monokle/validation": "0.15.0",
+        "@monokle/validation": "0.15.1",
         "@rjsf/antd": "5.0.0-beta.11",
         "@storybook/addon-actions": "6.5.16",
         "@storybook/addon-essentials": "6.5.16",
@@ -40729,7 +40725,7 @@
     "monaco-kubernetes": {
       "version": "file:packages/monaco-kubernetes",
       "requires": {
-        "@monokle/validation": "^0.15.0",
+        "@monokle/validation": "^0.15.1",
         "@types/json-schema": "^7.0.0",
         "@types/uuid": "9.0.0",
         "esbuild": "^0.15.0",
@@ -44983,9 +44979,6 @@
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"
       }
-    },
-    "tiny-invariant": {
-      "version": "1.2.0"
     },
     "tinybench": {
       "version": "2.4.0",

--- a/packages/monaco-kubernetes/package.json
+++ b/packages/monaco-kubernetes/package.json
@@ -39,7 +39,7 @@
     "kubernetes"
   ],
   "dependencies": {
-    "@monokle/validation": "^0.15.0",
+    "@monokle/validation": "^0.15.1",
     "@types/json-schema": "^7.0.0",
     "jsonc-parser": "^3.0.0",
     "monaco-marker-data-provider": "^1.0.0",


### PR DESCRIPTION
This PR updates monaco-kubernetes to latest validation version that fixes Argo CD build.