### PR TITLE
fix: show/hide column without destroy ResizableColumnsPanel component

### DIFF
--- a/.changeset/ninety-spies-talk.md
+++ b/.changeset/ninety-spies-talk.md
@@ -1,0 +1,5 @@
+---
+"@monokle/components": patch
+---
+
+show/hide columns without destroy the react component to keep the component's state

--- a/packages/components/src/molecules/Panels/ResizableColumnsPanel.tsx
+++ b/packages/components/src/molecules/Panels/ResizableColumnsPanel.tsx
@@ -21,9 +21,6 @@ const ResizableColumnsPanel: React.FC<ResizableColumnsPanelType> = props => {
       <StyledLeftReflexElement
         style={{
           display: !left ? 'none' : undefined,
-          flexGrow: !left ? 0 : undefined,
-          flexShrink: 1,
-          flexBasis: !left ? 0 : undefined,
         }}
         $leftClosable={leftClosable}
         minSize={minPaneWidth}
@@ -50,20 +47,23 @@ const ResizableColumnsPanel: React.FC<ResizableColumnsPanelType> = props => {
         style={{display: !left ? 'none' : undefined, backgroundColor: Colors.grey10}}
       />
 
-      <DynamicReflexElement
+      <ReflexElement
         style={{
           display: !center ? 'none' : undefined,
         }}
         minSize={minPaneWidth}
         maxSize={minPaneWidth + 200}
         onStopResize={onStopResizeCenter}
-        flexGrow={0.5}
       >
         <StyledPane>{center}</StyledPane>
-      </DynamicReflexElement>
+      </ReflexElement>
 
       <ReflexSplitter propagate={Boolean(left)} style={{display: !center ? 'none' : undefined}} />
-      <DynamicReflexElement flexGrow={0.5} minSize={minPaneWidth} onStopResize={onStopResizeRight}>
+      <DynamicReflexElement
+        flexGrow={!left || !center ? 1 : undefined}
+        minSize={minPaneWidth}
+        onStopResize={onStopResizeRight}
+      >
         <StyledPane>{right}</StyledPane>
       </DynamicReflexElement>
     </ReflexContainer>
@@ -97,14 +97,14 @@ const DynamicReflexElement = styled(ReflexElement)<{flexGrow?: number}>`
     if (flexGrow) {
       return `
       flex-grow: ${flexGrow} !important;
-      flex-shrink: 0 !important;
+      flex-shrink: 1 !important;
       flex-basis: 0% !important;
       `;
     }
   }}
 `;
 
-const StyledLeftReflexElement = styled(ReflexElement)<{$leftClosable: boolean}>`
+const StyledLeftReflexElement = styled(DynamicReflexElement)<{$leftClosable: boolean}>`
   ${({$leftClosable}) => {
     if ($leftClosable) {
       return `overflow: visible !important;`;

--- a/packages/components/src/molecules/Panels/ResizableColumnsPanel.tsx
+++ b/packages/components/src/molecules/Panels/ResizableColumnsPanel.tsx
@@ -18,49 +18,54 @@ const ResizableColumnsPanel: React.FC<ResizableColumnsPanelType> = props => {
 
   return (
     <ReflexContainer orientation="vertical" windowResizeAware style={{height, width}}>
-      {left && (
-        <StyledLeftReflexElement
-          $leftClosable={leftClosable}
-          minSize={minPaneWidth}
-          onStopResize={onStopResizeLeft}
-          flex={layout?.left}
-        >
-          <StyledLeftPane $leftClosable={leftClosable}>
-            {left}
-            {leftClosable && (
-              <PaneCloseIcon
-                onClick={onCloseLeftPane}
-                containerStyle={{
-                  position: 'absolute',
-                  top: 20,
-                  right: -10,
-                  zIndex: LAYOUT.zIndex.low,
-                  ...paneCloseIconStyle,
-                }}
-              />
-            )}
-          </StyledLeftPane>
-        </StyledLeftReflexElement>
-      )}
+      <StyledLeftReflexElement
+        style={{
+          display: !left ? 'none' : undefined,
+          flexGrow: !left ? 0 : undefined,
+          flexShrink: 1,
+          flexBasis: !left ? 0 : undefined,
+        }}
+        $leftClosable={leftClosable}
+        minSize={minPaneWidth}
+        onStopResize={onStopResizeLeft}
+      >
+        <StyledLeftPane $leftClosable={leftClosable}>
+          {left}
+          {leftClosable && (
+            <PaneCloseIcon
+              onClick={onCloseLeftPane}
+              containerStyle={{
+                position: 'absolute',
+                top: 20,
+                right: -10,
+                zIndex: LAYOUT.zIndex.low,
+                ...paneCloseIconStyle,
+              }}
+            />
+          )}
+        </StyledLeftPane>
+      </StyledLeftReflexElement>
+      <ReflexSplitter
+        propagate={Boolean(left)}
+        style={{display: !left ? 'none' : undefined, backgroundColor: Colors.grey10}}
+      />
 
-      {left && <ReflexSplitter propagate style={{backgroundColor: Colors.grey10}} />}
+      <DynamicReflexElement
+        style={{
+          display: !center ? 'none' : undefined,
+        }}
+        minSize={minPaneWidth}
+        maxSize={minPaneWidth + 200}
+        onStopResize={onStopResizeCenter}
+        flexGrow={0.5}
+      >
+        <StyledPane>{center}</StyledPane>
+      </DynamicReflexElement>
 
-      {center && (
-        <ReflexElement
-          minSize={minPaneWidth}
-          maxSize={minPaneWidth + 200}
-          onStopResize={onStopResizeCenter}
-          flex={layout?.center}
-        >
-          <StyledPane>{center}</StyledPane>
-        </ReflexElement>
-      )}
-
-      {center && <ReflexSplitter propagate={Boolean(left)} />}
-
-      <ReflexElement minSize={minPaneWidth} onStopResize={onStopResizeRight}>
+      <ReflexSplitter propagate={Boolean(left)} style={{display: !center ? 'none' : undefined}} />
+      <DynamicReflexElement flexGrow={0.5} minSize={minPaneWidth} onStopResize={onStopResizeRight}>
         <StyledPane>{right}</StyledPane>
-      </ReflexElement>
+      </DynamicReflexElement>
     </ReflexContainer>
   );
 };
@@ -83,6 +88,18 @@ const StyledLeftPane = styled(StyledPane)<{$leftClosable: boolean}>`
   ${({$leftClosable}) => {
     if ($leftClosable) {
       return `position: static;`;
+    }
+  }}
+`;
+
+const DynamicReflexElement = styled(ReflexElement)<{flexGrow?: number}>`
+  ${({flexGrow}) => {
+    if (flexGrow) {
+      return `
+      flex-grow: ${flexGrow} !important;
+      flex-shrink: 0 !important;
+      flex-basis: 0% !important;
+      `;
     }
   }}
 `;

--- a/packages/components/src/molecules/Panels/ResizableColumnsPanel.tsx
+++ b/packages/components/src/molecules/Panels/ResizableColumnsPanel.tsx
@@ -104,7 +104,7 @@ const DynamicReflexElement = styled(ReflexElement)<{flexGrow?: number}>`
   }}
 `;
 
-const StyledLeftReflexElement = styled(DynamicReflexElement)<{$leftClosable: boolean}>`
+const StyledLeftReflexElement = styled(ReflexElement)<{$leftClosable: boolean}>`
   ${({$leftClosable}) => {
     if ($leftClosable) {
       return `overflow: visible !important;`;


### PR DESCRIPTION
When we show hide columns in the ResizableColumnsPanel, the component loses its state. We want to maintain the state while showing/hiding columns.
