### PR TITLE
refactor: check abort signals before each resource validation

### DIFF
--- a/packages/validation/src/common/AbstractPlugin.ts
+++ b/packages/validation/src/common/AbstractPlugin.ts
@@ -192,10 +192,14 @@ export abstract class AbstractPlugin implements Plugin {
     return;
   }
 
-  async validate(resources: Resource[], incremental?: Incremental): Promise<ValidationRun> {
+  async validate(
+    resources: Resource[],
+    incremental?: Incremental,
+    abortSignals?: AbortSignal[]
+  ): Promise<ValidationRun> {
     invariant(this.configured, NOT_CONFIGURED_ERR_MSG(this.name));
 
-    let results = await this.doValidate(resources, incremental);
+    let results = await this.doValidate(resources, incremental, abortSignals);
 
     if (incremental) {
       results = this.merge(this._previous, results, incremental);
@@ -214,7 +218,11 @@ export abstract class AbstractPlugin implements Plugin {
     };
   }
 
-  protected abstract doValidate(resources: Resource[], incremental?: Incremental): Promise<ValidationResult[]>;
+  protected abstract doValidate(
+    resources: Resource[],
+    incremental?: Incremental,
+    abortSignals?: AbortSignal[]
+  ): Promise<ValidationResult[]>;
 
   protected getRuleConfig(ruleId: string): RuleConfig {
     const ruleConfig = this._ruleConfig.get(ruleId);

--- a/packages/validation/src/common/types.ts
+++ b/packages/validation/src/common/types.ts
@@ -220,7 +220,7 @@ export interface Plugin {
   registerCustomSchema(schema: CustomSchema): Promise<void> | void;
   unregisterCustomSchema(schema: Omit<CustomSchema, 'schema'>): Promise<void> | void;
 
-  validate(resources: Resource[], incremental?: Incremental): Promise<ValidationRun>;
+  validate(resources: Resource[], incremental?: Incremental, abortSignals?: AbortSignal[]): Promise<ValidationRun>;
 
   clear(): Promise<void>;
   unload(): Promise<void>;

--- a/packages/validation/src/types.ts
+++ b/packages/validation/src/types.ts
@@ -42,7 +42,7 @@ export interface Validator {
   validate(args: {
     resources: Resource[];
     incremental?: Incremental;
-    abortSignal?: AbortSignal;
+    abortSignals?: AbortSignal[];
   }): Promise<ValidationResponse>;
 
   /**

--- a/packages/validation/src/utils/abort.ts
+++ b/packages/validation/src/utils/abort.ts
@@ -14,7 +14,7 @@ export class AbortError extends ExtendableError {
 /**
  * Throws an AbortError if any signal is aborted.
  */
-export function throwIfAborted(...signals: (AbortSignal | undefined)[]) {
+export function throwIfAborted(signals: AbortSignal[] = []) {
   // AbortSignal.throwIfAborted exists but is not supported in NodeJs <v17.3.0
   // and it is also not available in abort-controller polyfill.
   // See https://nodejs.org/api/globals.html#abortsignalthrowifaborted

--- a/packages/validation/src/validators/resource-links/validator.ts
+++ b/packages/validation/src/validators/resource-links/validator.ts
@@ -1,6 +1,7 @@
 import {AbstractPlugin} from '../../common/AbstractPlugin.js';
 import {Region, ValidationResult} from '../../common/sarif.js';
-import {Resource, ResourceRef, ResourceRefType, ToolConfig} from '../../common/types.js';
+import {Incremental, Resource, ResourceRef, ResourceRefType, ToolConfig} from '../../common/types.js';
+import {throwIfAborted} from '../../utils/abort.js';
 import {createLocations} from '../../utils/createLocations.js';
 import {isDefined} from '../../utils/isDefined.js';
 import {RESOURCE_LINK_RULES} from './rules.js';
@@ -33,10 +34,15 @@ export class ResourceLinksValidator extends AbstractPlugin {
     return current;
   }
 
-  async doValidate(resources: Resource[]): Promise<ValidationResult[]> {
+  async doValidate(
+    resources: Resource[],
+    incremental?: Incremental,
+    abortSignals?: AbortSignal[]
+  ): Promise<ValidationResult[]> {
     const results: ValidationResult[] = [];
 
     for (const resource of resources) {
+      throwIfAborted(abortSignals);
       const resourceErrors = await this.validateResource(resource);
       results.push(...resourceErrors);
     }


### PR DESCRIPTION
This PR...

## Changes

- modified `validate` and `doValidate` method types to accept an `abortSignals` array
- after each resource validation, check if we should throw due to an abort signal
- added abort singals for `processRefs`

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
