### PR TITLE
Introduce metadata validation plugin

### DIFF
--- a/.changeset/polite-ducks-cover.md
+++ b/.changeset/polite-ducks-cover.md
@@ -1,0 +1,5 @@
+---
+"@monokle/validation": minor
+---
+
+introduce metadata validation plugin

--- a/packages/components/src/molecules/ValidationOverview/constants.tsx
+++ b/packages/components/src/molecules/ValidationOverview/constants.tsx
@@ -22,4 +22,5 @@ export const CORE_PLUGINS = [
   'yaml-syntax',
   'resource-links',
   'open-policy-agent',
+  'metadata',
 ];

--- a/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
@@ -9,7 +9,7 @@ import {ResourceParser} from '../common/resourceParser.js';
 import {createDefaultMonokleValidator} from '../createDefaultMonokleValidator.node.js';
 import { Config, RuleMap } from '../config/parse.js';
 
-it('should detect missing required labels (MTD001)', async () => {
+it('should detect missing required labels (MTD-recommended-labels)', async () => {
   const {response} = await processResourcesInFolder('src/__tests__/resources/metadata');
 
   const hasErrors = response.runs.reduce((sum, r) => sum + r.results.length, 0);
@@ -17,11 +17,11 @@ it('should detect missing required labels (MTD001)', async () => {
   expect(hasErrors).toBe(1);
 
   const result = response.runs[0].results[0];
-  expectResult(result, 'MTD001', 'error', 'ReplicaSet');
+  expectResult(result, 'MTD-recommended-labels', 'error', 'ReplicaSet');
   expectMatchList(result.message.text, ['app.kubernetes.io/component', 'app.kubernetes.io/part-of', 'app.kubernetes.io/managed']);
 });
 
-it('should detect missing redefined required labels (MTD001)', async () => {
+it('should detect missing redefined required labels (MTD-recommended-labels)', async () => {
   const {response} = await processResourcesInFolder('src/__tests__/resources/metadata', {
     'metadata/recommended-labels': ['err', ['app', 'tier', 'role']]
   });
@@ -31,12 +31,12 @@ it('should detect missing redefined required labels (MTD001)', async () => {
   expect(hasErrors).toBe(1);
 
   const result = response.runs[0].results[0];
-  expectResult(result, 'MTD001', 'error', 'ReplicaSet');
+  expectResult(result, 'MTD-recommended-labels', 'error', 'ReplicaSet');
   expectMatchList(result.message.text, ['role']);
   expect(result.message.text).not.toMatch('app.kubernetes.io/version');
 });
 
-it('should detect missing custom labels (MTD002)', async () => {
+it('should detect missing custom labels (MTD-custom-labels)', async () => {
   const {response} = await processResourcesInFolder('src/__tests__/resources/metadata', {
     'metadata/recommended-labels': false,
     'metadata/custom-labels': ['warn', ['app', 'tier', 'role']]
@@ -47,12 +47,12 @@ it('should detect missing custom labels (MTD002)', async () => {
   expect(hasErrors).toBe(1);
 
   const result = response.runs[0].results[0];
-  expectResult(result, 'MTD002', 'warning', 'ReplicaSet');
+  expectResult(result, 'MTD-custom-labels', 'warning', 'ReplicaSet');
   expectMatchList(result.message.text, ['role']);
   expect(result.message.text).not.toMatch('app.kubernetes.io/version');
 });
 
-it('should detect missing annotations labels (MTD002)', async () => {
+it('should detect missing annotations labels (MTD-custom-annotations)', async () => {
   const {response} = await processResourcesInFolder('src/__tests__/resources/metadata', {
     'metadata/recommended-labels': false,
     'metadata/custom-annotations': ['warn', ['revision', 'hash', 'annotation-1', 'annotation-2']]
@@ -63,7 +63,7 @@ it('should detect missing annotations labels (MTD002)', async () => {
   expect(hasErrors).toBe(1);
 
   const result = response.runs[0].results[0];
-  expectResult(result, 'MTD003', 'warning', 'ReplicaSet');
+  expectResult(result, 'MTD-custom-annotations', 'warning', 'ReplicaSet');
   expectMatchList(result.message.text, ['annotation-1', 'annotation-2']);
   expectNotMatchList(result.message.text, ['revision', 'hash']);
 });

--- a/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
@@ -172,8 +172,6 @@ it('should detect missing dynamic custom annotations', async () => {
   expectMatchList(result2.message.text, ['monokle.io/namespace', 'minikube, kube-system']);
 });
 
-// location when there is no metadata or metadata.labels path
-
 it('should detect missing recommended labels even with no metadata at all (MTD-recommended-labels)', async () => {
   const {response} = await processResourcesInFolder('src/__tests__/resources/no-metadata');
 

--- a/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
@@ -1,0 +1,84 @@
+import {expect, it} from 'vitest';
+import {MonokleValidator} from '../MonokleValidator.js';
+import {processRefs} from '../references/process.js';
+
+// Usage note: This library relies on fetch being on global scope!
+import 'isomorphic-fetch';
+import {expectResult, extractK8sResources, readDirectory} from './testUtils.js';
+import {ResourceParser} from '../common/resourceParser.js';
+import {createDefaultMonokleValidator} from '../createDefaultMonokleValidator.node.js';
+import { Config, RuleMap } from '../config/parse.js';
+
+it('should detect missing required labels (MTD001)', async () => {
+  const {response} = await processResourcesInFolder('src/__tests__/resources/metadata');
+
+  const hasErrors = response.runs.reduce((sum, r) => sum + r.results.length, 0);
+
+  expect(hasErrors).toBe(1);
+
+  const result = response.runs[0].results[0];
+  expectResult(result, 'MTD001', 'error', 'ReplicaSet');
+  expectMatchList(result.message.text, ['app.kubernetes.io/component', 'app.kubernetes.io/part-of', 'app.kubernetes.io/managed']);
+});
+
+it('should detect missing redefined required labels (MTD001)', async () => {
+  const {response} = await processResourcesInFolder('src/__tests__/resources/metadata', {
+    'metadata/recommended-labels': ['err', ['app', 'tier', 'role']]
+  });
+
+  const hasErrors = response.runs.reduce((sum, r) => sum + r.results.length, 0);
+
+  expect(hasErrors).toBe(1);
+
+  const result = response.runs[0].results[0];
+  expectResult(result, 'MTD001', 'error', 'ReplicaSet');
+  expectMatchList(result.message.text, ['role']);
+  expect(result.message.text).not.toMatch('app.kubernetes.io/version');
+});
+
+// MTD002
+// MTD003
+// custom-labels
+// custom-annotations
+// mixed
+// overrides
+
+async function processResourcesInFolder(path: string, rules?: RuleMap) {
+  const files = await readDirectory(path);
+  const resources = extractK8sResources(files);
+
+  const parser = new ResourceParser();
+  const validator = createDefaultMonokleValidator(parser);
+
+  await configureValidator(validator, rules);
+
+  processRefs(
+    resources,
+    parser,
+    undefined,
+    files.map(f => f.path)
+  );
+  const response = await validator.validate({resources});
+  return {response, resources};
+}
+
+async function configureValidator(validator: MonokleValidator, rules?: RuleMap) {
+  const config: Config = {
+    plugins: {
+      'metadata': true,
+    },
+    settings: {
+      debug: true,
+    },
+  };
+
+  if (rules) {
+    config.rules = rules;
+  }
+
+  return validator.preload(config);
+}
+
+function expectMatchList(message: string, expected: string[]) {
+  expected.forEach(e => expect(message).toMatch(e));
+}

--- a/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
@@ -60,18 +60,45 @@ it('should detect missing annotations labels (MTD-custom-annotations)', async ()
 
   const hasErrors = response.runs.reduce((sum, r) => sum + r.results.length, 0);
 
-  expect(hasErrors).toBe(1);
+  expect(hasErrors).toBe(2);
 
-  const result = response.runs[0].results[0];
-  expectResult(result, 'MTD-custom-annotations', 'warning', 'ReplicaSet');
-  expectMatchList(result.message.text, ['annotation-1', 'annotation-2']);
-  expectNotMatchList(result.message.text, ['revision', 'hash']);
+  const result1 = response.runs[0].results[0];
+  expectResult(result1, 'MTD-custom-annotations', 'warning', 'ReplicaSet');
+  expectMatchList(result1.message.text, ['annotation-1']);
+  expectNotMatchList(result1.message.text, ['revision', 'hash', 'annotation-2']);
+
+  const result2 = response.runs[0].results[1];
+  expectResult(result2, 'MTD-custom-annotations', 'warning', 'ReplicaSet');
+  expectMatchList(result2.message.text, ['annotation-2']);
+  expectNotMatchList(result2.message.text, ['revision', 'hash', 'annotation-1']);
 });
 
-// custom-labels
+it('should detect missing dynamic custom labels', async () => {
+  const {response} = await processResourcesInFolder('src/__tests__/resources/metadata', {
+    'metadata/recommended-labels': false,
+    'metadata/app-label': 'warn',
+    'metadata/tier-label': 'warn',
+    'metadata/role-label': ['warn', ['dev', 'stage', 'prod']],
+    'metadata/name-label': 'err',
+  });
+
+  const hasErrors = response.runs.reduce((sum, r) => sum + r.results.length, 0);
+
+  expect(hasErrors).toBe(2);
+
+  const result1 = response.runs[0].results[0];
+  expectResult(result1, 'MTD-role-label', 'warning', 'ReplicaSet');
+  expectMatchList(result1.message.text, ['role']);
+
+  const result2 = response.runs[0].results[1];
+  expectResult(result2, 'MTD-name-label', 'error', 'ReplicaSet');
+  expectMatchList(result2.message.text, ['name']);
+});
+
+// custom-labels with defined values
 // custom-annotations
-// mixed
-// overrides
+// overrides of predefined labels
+// no overrides for recommended labels
 // location when there is no metadata or metadata.labels path
 
 async function processResourcesInFolder(path: string, rules?: RuleMap) {

--- a/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
@@ -36,12 +36,43 @@ it('should detect missing redefined required labels (MTD001)', async () => {
   expect(result.message.text).not.toMatch('app.kubernetes.io/version');
 });
 
-// MTD002
-// MTD003
+it('should detect missing custom labels (MTD002)', async () => {
+  const {response} = await processResourcesInFolder('src/__tests__/resources/metadata', {
+    'metadata/recommended-labels': false,
+    'metadata/custom-labels': ['warn', ['app', 'tier', 'role']]
+  });
+
+  const hasErrors = response.runs.reduce((sum, r) => sum + r.results.length, 0);
+
+  expect(hasErrors).toBe(1);
+
+  const result = response.runs[0].results[0];
+  expectResult(result, 'MTD002', 'warning', 'ReplicaSet');
+  expectMatchList(result.message.text, ['role']);
+  expect(result.message.text).not.toMatch('app.kubernetes.io/version');
+});
+
+it('should detect missing annotations labels (MTD002)', async () => {
+  const {response} = await processResourcesInFolder('src/__tests__/resources/metadata', {
+    'metadata/recommended-labels': false,
+    'metadata/custom-annotations': ['warn', ['revision', 'hash', 'annotation-1', 'annotation-2']]
+  });
+
+  const hasErrors = response.runs.reduce((sum, r) => sum + r.results.length, 0);
+
+  expect(hasErrors).toBe(1);
+
+  const result = response.runs[0].results[0];
+  expectResult(result, 'MTD003', 'warning', 'ReplicaSet');
+  expectMatchList(result.message.text, ['annotation-1', 'annotation-2']);
+  expectNotMatchList(result.message.text, ['revision', 'hash']);
+});
+
 // custom-labels
 // custom-annotations
 // mixed
 // overrides
+// location when there is no metadata or metadata.labels path
 
 async function processResourcesInFolder(path: string, rules?: RuleMap) {
   const files = await readDirectory(path);
@@ -81,4 +112,8 @@ async function configureValidator(validator: MonokleValidator, rules?: RuleMap) 
 
 function expectMatchList(message: string, expected: string[]) {
   expected.forEach(e => expect(message).toMatch(e));
+}
+
+function expectNotMatchList(message: string, expected: string[]) {
+  expected.forEach(e => expect(message).not.toMatch(e));
 }

--- a/packages/validation/src/__tests__/resources/metadata/replica-set.yaml
+++ b/packages/validation/src/__tests__/resources/metadata/replica-set.yaml
@@ -5,12 +5,16 @@ metadata:
   labels:
     app: guestbook
     tier: frontend
+    monokle.io/namespace: default
+    monokle.io/group: local
+    monokle.io/user: ""
     app.kubernetes.io/name: rs
     app.kubernetes.io/instance: rs-1
     app.kubernetes.io/version: ""
   annotations:
     revision: "1"
     hash: "123dsd3"
+    monokle.io/namespace: default
 spec:
   replicas: 3
   selector:

--- a/packages/validation/src/__tests__/resources/metadata/replica-set.yaml
+++ b/packages/validation/src/__tests__/resources/metadata/replica-set.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1beta2
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: guestbook
+    tier: frontend
+    app.kubernetes.io/name: rs
+    app.kubernetes.io/instance: rs-1
+    app.kubernetes.io/version: ""
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google_samples/gb-frontend:v3

--- a/packages/validation/src/__tests__/resources/metadata/replica-set.yaml
+++ b/packages/validation/src/__tests__/resources/metadata/replica-set.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/name: rs
     app.kubernetes.io/instance: rs-1
     app.kubernetes.io/version: ""
+  annotations:
+    revision: "1"
+    hash: "123dsd3"
 spec:
   replicas: 3
   selector:

--- a/packages/validation/src/__tests__/resources/no-metadata/replica-set.yaml
+++ b/packages/validation/src/__tests__/resources/no-metadata/replica-set.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1beta2
+kind: ReplicaSet
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google_samples/gb-frontend:v3

--- a/packages/validation/src/common/AbstractPlugin.ts
+++ b/packages/validation/src/common/AbstractPlugin.ts
@@ -142,10 +142,13 @@ export abstract class AbstractPlugin implements Plugin {
   }
 
   async configure(config: {rules?: RuleMap; settings?: any}): Promise<void> {
+    this.preconfigureRules(config.rules);
     this.configureRules(config.rules);
     await this.configurePlugin(config.settings);
     this.configured = true;
   }
+
+  protected preconfigureRules(rules: RuleMap = {}) {}
 
   protected configureRules(rules: RuleMap = {}) {
     this._ruleConfig.clear();

--- a/packages/validation/src/constants.ts
+++ b/packages/validation/src/constants.ts
@@ -24,4 +24,5 @@ export const CORE_PLUGINS = [
   'yaml-syntax',
   'resource-links',
   'open-policy-agent',
+  'metadata',
 ] as const;

--- a/packages/validation/src/createDefaultMonokleValidator.browser.ts
+++ b/packages/validation/src/createDefaultMonokleValidator.browser.ts
@@ -6,6 +6,7 @@ import {RemoteWasmLoader} from './wasmLoader/RemoteWasmLoader.browser.js';
 import {OpenPolicyAgentValidator} from './validators/open-policy-agent/validator.js';
 import {ResourceLinksValidator} from './validators/resource-links/validator.js';
 import {YamlValidator} from './validators/yaml-syntax/validator.js';
+import {MetadataValidator} from './validators/metadata/validator.js';
 import {MonokleValidator} from './MonokleValidator.js';
 import kbpPlugin from './validators/practices/plugin.js';
 import pssPlugin from './validators/pod-security-standards/plugin.js';
@@ -39,6 +40,8 @@ export function createDefaultPluginLoader(
         return new SimpleCustomValidator(labelPlugin.default, parser);
       case 'kubernetes-schema':
         return new KubernetesSchemaValidator(parser, schemaLoader);
+      case 'metadata':
+        return new MetadataValidator(parser);
       default:
         throw new Error('plugin_not_found');
     }

--- a/packages/validation/src/createDefaultMonokleValidator.node.ts
+++ b/packages/validation/src/createDefaultMonokleValidator.node.ts
@@ -9,6 +9,7 @@ import {RemoteWasmLoader} from './wasmLoader/RemoteWasmLoader.browser.js';
 import {OpenPolicyAgentValidator} from './validators/open-policy-agent/validator.js';
 import {ResourceLinksValidator} from './validators/resource-links/validator.js';
 import {YamlValidator} from './validators/yaml-syntax/validator.js';
+import {MetadataValidator} from './validators/metadata/validator.js';
 import {MonokleValidator} from './MonokleValidator.js';
 import {bundlePluginCode} from './utils/loadCustomPlugin.node.js';
 import practicesPlugin from './validators/practices/plugin.js';
@@ -43,6 +44,8 @@ export function createDefaultPluginLoader(
         return new YamlValidator(parser);
       case 'kubernetes-schema':
         return new KubernetesSchemaValidator(parser, schemaLoader);
+      case 'metadata':
+        return new MetadataValidator(parser);
       default:
         throw new Error('plugin_not_found');
     }

--- a/packages/validation/src/createExtensibleMonokleValidator.browser.ts
+++ b/packages/validation/src/createExtensibleMonokleValidator.browser.ts
@@ -9,6 +9,7 @@ import {RemoteWasmLoader} from './wasmLoader/RemoteWasmLoader.browser.js';
 import {OpenPolicyAgentValidator} from './validators/open-policy-agent/validator.js';
 import {ResourceLinksValidator} from './validators/resource-links/validator.js';
 import {YamlValidator} from './validators/yaml-syntax/validator.js';
+import {MetadataValidator} from './validators/metadata/validator.js';
 import kbpPlugin from './validators/practices/plugin.js';
 import pssPlugin from './validators/pod-security-standards/plugin.js';
 
@@ -37,6 +38,8 @@ export function createExtensibleMonokleValidator(
         return new SimpleCustomValidator(labelPlugin.default, parser);
       case 'kubernetes-schema':
         return new KubernetesSchemaValidator(parser, schemaLoader);
+      case 'metadata':
+        return new MetadataValidator(parser);
       case DEV_MODE_TOKEN:
         return new DevCustomValidator(parser);
       default:

--- a/packages/validation/src/createExtensibleMonokleValidator.node.ts
+++ b/packages/validation/src/createExtensibleMonokleValidator.node.ts
@@ -10,6 +10,7 @@ import {RemoteWasmLoader} from './wasmLoader/RemoteWasmLoader.node.js';
 import {OpenPolicyAgentValidator} from './validators/open-policy-agent/validator.js';
 import {ResourceLinksValidator} from './validators/resource-links/validator.js';
 import {YamlValidator} from './validators/yaml-syntax/validator.js';
+import {MetadataValidator} from './validators/metadata/validator.js';
 import {bundlePluginCode, loadCustomPlugin} from './utils/loadCustomPlugin.node.js';
 import kbpPlugin from './validators/practices/plugin.js';
 import pssPlugin from './validators/pod-security-standards/plugin.js';
@@ -39,6 +40,8 @@ export function createExtensibleMonokleValidator(
         return new YamlValidator(parser);
       case 'kubernetes-schema':
         return new KubernetesSchemaValidator(parser, schemaLoader);
+      case 'metadata':
+        return new MetadataValidator(parser);
       default:
         try {
           const customPlugin = await loadCustomPlugin(pluginName);

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -18,6 +18,7 @@ export * from './validators/open-policy-agent/index.js';
 export * from './validators/kubernetes-schema/index.js';
 export * from './validators/yaml-syntax/index.js';
 export * from './validators/resource-links/index.js';
+export * from './validators/metadata/index.js';
 
 export * from './references/process.js';
 

--- a/packages/validation/src/utils/findJsonPointerNode.ts
+++ b/packages/validation/src/utils/findJsonPointerNode.ts
@@ -1,0 +1,23 @@
+import {Document, isCollection, ParsedNode} from 'yaml';
+
+export function findJsonPointerNode(valuesDoc: Document.Parsed<ParsedNode>, path: string[]) {
+  if (!valuesDoc.contents) {
+    return undefined;
+  }
+
+  let valueNode: any = valuesDoc.contents;
+
+  for (let c = 0; valueNode && c < path.length; c += 1) {
+    let node = path[c];
+    if (isCollection(valueNode)) {
+      const nextNode = valueNode.get(node, true);
+      if (nextNode) {
+        valueNode = nextNode;
+      } else {
+        return valueNode;
+      }
+    } else break;
+  }
+
+  return valueNode;
+}

--- a/packages/validation/src/validators/kubernetes-schema/validator.ts
+++ b/packages/validation/src/validators/kubernetes-schema/validator.ts
@@ -1,5 +1,4 @@
-import Ajv, {ErrorObject, ValidateFunction} from 'ajv';
-import {Document, isCollection, ParsedNode} from 'yaml';
+import Ajv, {ValidateFunction} from 'ajv';
 import {z} from 'zod';
 import {AbstractPlugin} from '../../common/AbstractPlugin.js';
 import {ResourceParser} from '../../common/resourceParser.js';
@@ -12,6 +11,7 @@ import {matchResourceSchema} from './resourcePrefixMap.js';
 import {KUBERNETES_SCHEMA_RULES} from './rules.js';
 import {SchemaLoader} from './schemaLoader.js';
 import {validate} from './deprecation/validator.js';
+import {findJsonPointerNode} from '../../utils/findJsonPointerNode.js';
 
 type Settings = z.infer<typeof Settings>;
 const Settings = z.object({
@@ -176,26 +176,4 @@ export class KubernetesSchemaValidator extends AbstractPlugin {
       locations,
     });
   }
-}
-
-function findJsonPointerNode(valuesDoc: Document.Parsed<ParsedNode>, path: string[]) {
-  if (!valuesDoc.contents) {
-    return undefined;
-  }
-
-  let valueNode: any = valuesDoc.contents;
-
-  for (let c = 0; valueNode && c < path.length; c += 1) {
-    let node = path[c];
-    if (isCollection(valueNode)) {
-      const nextNode = valueNode.get(node, true);
-      if (nextNode) {
-        valueNode = nextNode;
-      } else {
-        return valueNode;
-      }
-    } else break;
-  }
-
-  return valueNode;
 }

--- a/packages/validation/src/validators/metadata/index.ts
+++ b/packages/validation/src/validators/metadata/index.ts
@@ -1,0 +1,1 @@
+export * from './validator.js';

--- a/packages/validation/src/validators/metadata/rules.ts
+++ b/packages/validation/src/validators/metadata/rules.ts
@@ -2,16 +2,16 @@ import {RuleMetadata} from '../../common/sarif.js';
 
 export const METADATA_RULES: RuleMetadata[] = [
   {
-    id: 'MTD001',
+    id: 'MTD-recommended-labels',
     name: 'recommended-labels',
     shortDescription: {
       text: 'Recommended labels are missing.',
     },
     fullDescription: {
-      text: '',
+      text: 'The resource is violating the recommended labels. The resource may not be discoverable by tools that rely on these labels.',
     },
     help: {
-      text: '',
+      text: 'Add all recommended labels. You can hover the key for documentation.',
     },
     defaultConfiguration: {
       level: 'error',
@@ -27,16 +27,16 @@ export const METADATA_RULES: RuleMetadata[] = [
     },
   },
   {
-    id: 'MTD002',
+    id: 'MTD-custom-labels',
     name: 'custom-labels',
     shortDescription: {
       text: 'Custom labels are missing.',
     },
     fullDescription: {
-      text: '',
+      text: 'The resource is violating the custom labels. The resource may not be discoverable by tools that rely on these labels.',
     },
     help: {
-      text: '',
+      text: 'Add all required custom labels. You can hover the key for documentation.',
     },
     defaultConfiguration: {
       enabled: false,
@@ -44,16 +44,16 @@ export const METADATA_RULES: RuleMetadata[] = [
     },
   },
   {
-    id: 'MTD003',
+    id: 'MTD-custom-annotations',
     name: 'custom-annotations',
     shortDescription: {
       text: 'Custom annotations are missing.',
     },
     fullDescription: {
-      text: '',
+      text: 'The resource is violating the custom annotations. The resource may not be discoverable by tools that rely on these annotations.',
     },
     help: {
-      text: '',
+      text: 'Add all required custom annotations. You can hover the key for documentation.',
     },
     defaultConfiguration: {
       enabled: false,

--- a/packages/validation/src/validators/metadata/rules.ts
+++ b/packages/validation/src/validators/metadata/rules.ts
@@ -1,0 +1,20 @@
+import {RuleMetadata} from '../../common/sarif.js';
+
+export const METADATA_RULES: RuleMetadata[] = [
+  {
+    id: 'MTD001',
+    name: 'recommended-labels',
+    shortDescription: {
+      text: 'Recommended labels are missing.',
+    },
+    fullDescription: {
+      text: '',
+    },
+    help: {
+      text: '',
+    },
+    defaultConfiguration: {
+      level: 'error',
+    },
+  },
+];

--- a/packages/validation/src/validators/metadata/rules.ts
+++ b/packages/validation/src/validators/metadata/rules.ts
@@ -15,6 +15,31 @@ export const METADATA_RULES: RuleMetadata[] = [
     },
     defaultConfiguration: {
       level: 'error',
+      // Based on https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+      parameters: [
+        'app.kubernetes.io/name',
+        'app.kubernetes.io/instance',
+        'app.kubernetes.io/version',
+        'app.kubernetes.io/component',
+        'app.kubernetes.io/part-of',
+        'app.kubernetes.io/managed',
+      ]
+    },
+  },
+  {
+    id: 'MTD002',
+    name: 'custom-labels',
+    shortDescription: {
+      text: 'Custom labels are missing.',
+    },
+    fullDescription: {
+      text: '',
+    },
+    help: {
+      text: '',
+    },
+    defaultConfiguration: {
+      level: 'warning',
     },
   },
 ];

--- a/packages/validation/src/validators/metadata/rules.ts
+++ b/packages/validation/src/validators/metadata/rules.ts
@@ -39,6 +39,24 @@ export const METADATA_RULES: RuleMetadata[] = [
       text: '',
     },
     defaultConfiguration: {
+      enabled: false,
+      level: 'warning',
+    },
+  },
+  {
+    id: 'MTD003',
+    name: 'custom-annotations',
+    shortDescription: {
+      text: 'Custom annotations are missing.',
+    },
+    fullDescription: {
+      text: '',
+    },
+    help: {
+      text: '',
+    },
+    defaultConfiguration: {
+      enabled: false,
       level: 'warning',
     },
   },

--- a/packages/validation/src/validators/metadata/validator.ts
+++ b/packages/validation/src/validators/metadata/validator.ts
@@ -1,0 +1,68 @@
+// import {YAMLError} from 'yaml';
+import {AbstractPlugin} from '../../common/AbstractPlugin.js';
+import {ResourceParser} from '../../common/resourceParser.js';
+import {ValidationResult} from '../../common/sarif.js';
+import {Incremental, Resource} from '../../common/types.js';
+// import {createLocations} from '../../utils/createLocations.js';
+// import {isDefined} from '../../utils/isDefined.js';
+import {METADATA_RULES} from './rules.js';
+
+export class MetadataValidator extends AbstractPlugin {
+  constructor(private resourceParser: ResourceParser) {
+    super(
+      {
+        id: 'MTD',
+        name: 'metadata',
+        displayName: 'Metadata',
+        description: 'Validates that your manifests have correct metadata fields and values.',
+        learnMoreUrl: 'https://kubeshop.github.io/monokle/resource-validation/',
+      },
+      METADATA_RULES
+    );
+  }
+
+  async doValidate(resources: Resource[], incremental?: Incremental): Promise<ValidationResult[]> {
+    const results: ValidationResult[] = [];
+    const dirtyResources = incremental ? resources.filter(r => incremental.resourceIds.includes(r.id)) : resources;
+
+    console.log(this._rules);
+    console.log(this._ruleConfig);
+
+    for (const resource of dirtyResources) {
+      // const resourceErrors = await this.validateResource(resource);
+      // results.push(...resourceErrors);
+    }
+
+    return results;
+  }
+
+  // /**
+  //  * Parse for YAML errors that were allowed by non-strict parsing
+  //  */
+  // private async validateResource(resource: Resource): Promise<ValidationResult[]> {
+  //   const {parsedDoc} = this.resourceParser.parse(resource, {
+  //     forceParse: true,
+  //   });
+
+  //   const results = parsedDoc.errors.map(err => this.adaptToValidationResult(resource, err)).filter(isDefined);
+
+  //   return results;
+  // }
+
+  // private adaptToValidationResult(resource: Resource, err: YAMLError) {
+  //   const region = this.resourceParser.parseErrorRegion(resource, err.pos);
+  //   const locations = createLocations(resource, region);
+  //   const ruleId = YAML_RULE_MAP[err.code];
+
+  //   const textWithoutLocation = err.message.split(' at line').at(0) ?? err.message;
+
+  //   return this.isRuleEnabled(ruleId)
+  //     ? this.createValidationResult(ruleId, {
+  //         message: {
+  //           text: textWithoutLocation,
+  //         },
+  //         locations,
+  //       })
+  //     : undefined;
+  // }
+}

--- a/packages/validation/src/validators/metadata/validator.ts
+++ b/packages/validation/src/validators/metadata/validator.ts
@@ -1,4 +1,3 @@
-import {Document, isCollection, ParsedNode} from 'yaml';
 import difference from 'lodash/difference.js';
 import intersection from 'lodash/intersection.js';
 import {AbstractPlugin} from '../../common/AbstractPlugin.js';
@@ -8,6 +7,7 @@ import {Incremental, Resource} from '../../common/types.js';
 import {METADATA_RULES} from './rules.js';
 import {createLocations} from '../../utils/createLocations.js';
 import {RuleMetadataWithConfig} from '../../types.js';
+import {findJsonPointerNode} from '../../utils/findJsonPointerNode.js';
 
 export class MetadataValidator extends AbstractPlugin {
   constructor(private resourceParser: ResourceParser) {
@@ -94,26 +94,4 @@ export class MetadataValidator extends AbstractPlugin {
       locations,
     });
   }
-}
-
-function findJsonPointerNode(valuesDoc: Document.Parsed<ParsedNode>, path: string[]) {
-  if (!valuesDoc.contents) {
-    return undefined;
-  }
-
-  let valueNode: any = valuesDoc.contents;
-
-  for (let c = 0; valueNode && c < path.length; c += 1) {
-    let node = path[c];
-    if (isCollection(valueNode)) {
-      const nextNode = valueNode.get(node, true);
-      if (nextNode) {
-        valueNode = nextNode;
-      } else {
-        return valueNode;
-      }
-    } else break;
-  }
-
-  return valueNode;
 }

--- a/packages/validation/src/validators/metadata/validator.ts
+++ b/packages/validation/src/validators/metadata/validator.ts
@@ -109,39 +109,36 @@ export class MetadataValidator extends AbstractPlugin {
     ).filter(isDefined)
   }
 
-  private validateRecommendedLabels (resource: Resource, rule: RuleMetadataWithConfig) {
+  private validateRecommendedLabels(resource: Resource, rule: RuleMetadataWithConfig) {
     return this.validateMap(
-      resource.content?.metadata?.labels ?? [],
-      rule.defaultConfiguration?.parameters ?? [],
-      []
+      resource.content?.metadata?.labels,
+      rule.defaultConfiguration?.parameters
     );
   }
 
   private validateCustomLabels(resource: Resource, rule: RuleMetadataWithConfig) {
     return this.validateMap(
-      resource.content?.metadata?.labels ?? [],
-      rule.configuration?.parameters ?? [],
-      []
+      resource.content?.metadata?.labels,
+      rule.configuration?.parameters
     );
   }
 
   private validateCustomAnnotations(resource: Resource, rule: RuleMetadataWithConfig) {
     return this.validateMap(
-      resource.content?.metadata?.annotations ?? [],
-      rule.configuration?.parameters ?? [],
-      []
+      resource.content?.metadata?.annotations,
+      rule.configuration?.parameters
     );
   }
 
   private validateDynamicRule(resource: Resource, rule: RuleMetadataWithConfig) {
     return this.validateMap(
-      (this.isLabelRule(rule.name) ? resource.content?.metadata?.labels : resource.content?.metadata?.annotations) ?? [],
+      this.isLabelRule(rule.name) ? resource.content?.metadata?.labels : resource.content?.metadata?.annotations,
       [rule.defaultConfiguration?.parameters?.name],
-      rule.configuration?.parameters ?? []
+      rule.configuration?.parameters
     );
   }
 
-  private validateMap(actualMap: {[key: string]: any}, expectedKeys: string[], expectedValues: string[]): string[] {
+  private validateMap(actualMap: {[key: string]: any} = {}, expectedKeys: string[] = [], expectedValues: string[] = []): string[] {
     if (!expectedKeys.length) {
       return [];
     }

--- a/packages/validation/src/validators/metadata/validator.ts
+++ b/packages/validation/src/validators/metadata/validator.ts
@@ -8,6 +8,8 @@ import {METADATA_RULES} from './rules.js';
 import {createLocations} from '../../utils/createLocations.js';
 import {RuleMetadataWithConfig} from '../../types.js';
 import {findJsonPointerNode} from '../../utils/findJsonPointerNode.js';
+import { RuleMap } from '../../config/parse.js';
+import { isDefined } from '../../utils/isDefined.js';
 
 export class MetadataValidator extends AbstractPlugin {
   constructor(private resourceParser: ResourceParser) {
@@ -23,59 +25,101 @@ export class MetadataValidator extends AbstractPlugin {
     );
   }
 
+  protected preconfigureRules(rules: RuleMap = {}) {
+    Object.entries(rules).forEach(rule => {
+      const ruleName = rule[0];
+
+      if (!ruleName.startsWith('metadata/') || !ruleName.endsWith('-label') && !ruleName.endsWith('-annotation')) {
+        return;
+      }
+
+      const isLabelRule = this.isLabelRule(ruleName);
+      const ruleTypeName = isLabelRule ? 'label' : 'annotation';
+      const ruleShortName = ruleName.replace('metadata/', '');
+      const ruleNormalizedName = ruleShortName.replace('__', '/').replace((isLabelRule ? /-label$/ : /-annotation$/), '');
+
+      this._rules.push({
+        id: `MTD-${ruleShortName}`,
+        name: ruleShortName,
+        shortDescription: { text: `The ${ruleNormalizedName} ${ruleTypeName} is missing.` },
+        fullDescription: {
+          text: `The resource is violating the ${ruleShortName}. The resource may not be discoverable by tools that rely on these ${ruleTypeName}s.`
+        },
+        help: {
+          text: `Add required ${ruleTypeName}. You can hover the key for documentation.`
+        },
+        defaultConfiguration: {
+          parameters: {name: ruleNormalizedName}
+          // rest of the configuration is set during 'this.configureRules()' method call
+        },
+      });
+    });
+
+    this.setRules(this._rules);
+  }
+
   async doValidate(resources: Resource[], incremental?: Incremental): Promise<ValidationResult[]> {
     const results: ValidationResult[] = [];
     const dirtyResources = incremental ? resources.filter(r => incremental.resourceIds.includes(r.id)) : resources;
 
     for (const resource of dirtyResources) {
       for (const rule of this.rules) {
-        const resourceError = this[this.isLabelRule(rule) ? 'validateLabels' : 'validateAnnotations'](resource, rule);
-
-        resourceError && results.push(resourceError);
+        const resourceErrors = this.validateResource(resource, rule);
+        results.push(...resourceErrors);
       }
     }
 
     return results;
   }
 
-  private isLabelRule(rule: RuleMetadataWithConfig) {
-    return rule.name.endsWith('-labels') || rule.name.endsWith('-label');
+  private isLabelRule(ruleName: string) {
+    return ruleName.endsWith('-labels') || ruleName.endsWith('-label');
   }
 
-  private validateAnnotations(resource: Resource, rule: RuleMetadataWithConfig) {
-    const invalidKeys = this.validateMap(resource.content?.metadata?.annotations ?? {}, rule.configuration?.parameters ?? []);
+  // We have special behavior for different rules (https://github.com/kubeshop/monokle-saas/issues/722):
+  // MTD-recommended-labels does not allow to config parameters (meaning label names or values).
+  // MTD-custom-labels and MTD-custom-annotations allows to define label/annotations expected names with config parameters.
+  // MTD-*-(label|annotation) (dynamic rules) allow to define expected values with config parameters.
+  private validateResource(resource: Resource, rule: RuleMetadataWithConfig) {
+    const isLabelRule = this.isLabelRule(rule.name);
+    const allowsNamesList = rule.id === 'MTD-custom-labels' || rule.id === 'MTD-custom-annotations';
+    const allowsValuesList = rule.name.endsWith('-label') || rule.name.endsWith('-annotation');
 
-    if (!invalidKeys.length) {
-      return undefined;
+    let expectedNames = allowsNamesList ? rule.configuration?.parameters ?? [] : rule.defaultConfiguration?.parameters ?? [];
+    const expectedValues = allowsValuesList ? rule.configuration?.parameters ?? [] : []; // if not defined it will contain rule name
+    const valuesMap = isLabelRule ? resource.content?.metadata?.labels ?? {} : resource.content?.metadata?.annotations ?? {};
+
+    if (allowsValuesList && rule.defaultConfiguration?.parameters?.name) {
+      expectedNames = [rule.defaultConfiguration?.parameters?.name];
     }
 
-    const errorMessage = `Missing valid: ${invalidKeys.join(', ')} ${invalidKeys.length > 1 ? 'annotations' : 'annotation'} in ${resource.kind}.`;
-
-    return this.adaptToValidationResult(resource, ['metadata', 'annotations'], rule.id, errorMessage);
-  }
-
-  private validateLabels(resource: Resource, rule: RuleMetadataWithConfig) {
-    const invalidKeys = this.validateMap(resource.content?.metadata?.labels ?? {}, rule.configuration?.parameters ?? []);
+    const invalidKeys = this.validateMap(valuesMap, expectedNames, expectedValues);
 
     if (!invalidKeys.length) {
-      return undefined;
+      return [];
     }
 
-    const errorMessage = `Missing valid: ${invalidKeys.join(', ')} ${invalidKeys.length > 1 ? 'labels' : 'label'} in ${resource.kind}.`;
-
-    return this.adaptToValidationResult(resource, ['metadata', 'labels'], rule.id, errorMessage);
+    return invalidKeys.map(key => this.adaptToValidationResult(
+        resource,
+        ['metadata', isLabelRule ? 'labels' : 'annotations'],
+        rule.id,
+        `Missing valid '${key}' ${isLabelRule ? 'label' : 'annotation'} in '${resource.kind}'.` // expected value: ${expectedValues.join(', ')}
+      )
+    ).filter(isDefined)
   }
 
-  private validateMap(actualMap: {[key: string]: any}, expectedKeys: string[]): string[] {
+  private validateMap(actualMap: {[key: string]: any}, expectedKeys: string[], expectedValues: string[]): string[] {
     if (!expectedKeys.length) {
       return [];
     }
 
     const missingLabels = difference(expectedKeys, Object.keys(actualMap));
-    const emptyLabels = Object.entries(actualMap).filter(([_, value]) => !value).map(([key, _]) => key);
-    const missingEmptyLabels = intersection(expectedKeys, emptyLabels);
+    const invalidLabels = expectedValues.length ?
+      Object.entries(actualMap).filter(([_, value]) => !expectedValues.includes(value)).map(([key, _]) => key):
+      Object.entries(actualMap).filter(([_, value]) => !value).map(([key, _]) => key);
+    const missingInvalidLabels = intersection(expectedKeys, invalidLabels);
 
-    return [...missingLabels, ...missingEmptyLabels].sort((a, b) => a.localeCompare(b));
+    return [...missingLabels, ...missingInvalidLabels].sort((a, b) => a.localeCompare(b));
   }
 
   private adaptToValidationResult(resource: Resource, path: string[], ruleId: string, errText: string) {


### PR DESCRIPTION
This PR introduces metadata plugin according to https://github.com/kubeshop/monokle-saas/issues/722.

## Changes

- Introduce separate `metadata` validation plugin, see linked issue on detailed description how it works.
- Introduced new `preconfigureRules()` method in `AbstractPlugin` class to hook into configuration process and generate dynamic rules based on configuration, see https://github.com/kubeshop/monokle-core/pull/387/commits/7640f046db66519b432115e65e8d630d15a17284. This method transforms dynamic `config.rules` entries to full rules definitions which then are processed by the plugin the same way as predefined rules.
- Did a bit of juggling with using `defaultConfig` and `config` rule object to then validate dynamic rules correctly - https://github.com/kubeshop/monokle-core/pull/387/files#diff-13637b23e7c89a76b08985103c8762a36c57eb771bdc6aff4cbe0120d9d79509R55-R57, https://github.com/kubeshop/monokle-core/pull/387/files#diff-13637b23e7c89a76b08985103c8762a36c57eb771bdc6aff4cbe0120d9d79509R91-R97.
- Added reasonable amount of tests.
- Used `MTD` as rule id prefix and then full rule name, like `MTD-recommended-labels` or `MTD-custom-label`. This way ids are stable and human-readable (in comparison to e.g. hashes).

## Questions

1. Should the plugin be added here - https://github.com/kubeshop/monokle-core/blob/c6cf0644b3695335ec82bf0e468ada8c95677cdf/packages/components/src/molecules/ValidationOverview/constants.tsx#L18-L25? Or registered in any other place?

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
