### PR TITLE
feat(validation): include configurability info in rule definition

### DIFF
--- a/.changeset/wet-humans-tickle.md
+++ b/.changeset/wet-humans-tickle.md
@@ -1,0 +1,5 @@
+---
+"@monokle/validation": minor
+---
+
+extend rules definition with config metadata

--- a/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
@@ -192,7 +192,7 @@ it('should have custom-* configurable rules', async () => {
 
   Object.entries(validator.rules)[0][1].forEach(rule => {
     if (rule.configuration.enabled) {
-      expect(rule.configurability).toBeDefined();
+      expect(rule.properties?.configurability).toBeDefined();
     }
   });
 });
@@ -212,7 +212,7 @@ it('should generate dynamic configurable rules', async () => {
 
   Object.entries(validator.rules)[0][1].forEach(rule => {
     if (rule.configuration.enabled) {
-      expect(rule.configurability).toBeDefined();
+      expect(rule.properties?.configurability).toBeDefined();
     }
   });
 });

--- a/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
@@ -192,7 +192,7 @@ it('should have custom-* configurable rules', async () => {
 
   Object.entries(validator.rules)[0][1].forEach(rule => {
     if (rule.configuration.enabled) {
-      expect(rule.properties?.configurability).toBeDefined();
+      expect(rule.properties?.configMetadata).toBeDefined();
     }
   });
 });
@@ -212,7 +212,7 @@ it('should generate dynamic configurable rules', async () => {
 
   Object.entries(validator.rules)[0][1].forEach(rule => {
     if (rule.configuration.enabled) {
-      expect(rule.properties?.configurability).toBeDefined();
+      expect(rule.properties?.configMetadata).toBeDefined();
     }
   });
 });

--- a/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
@@ -180,6 +180,43 @@ it('should detect missing recommended labels even with no metadata at all (MTD-r
   expect(hasErrors).toBe(6);
 });
 
+it('should have custom-* configurable rules', async () => {
+  const parser = new ResourceParser();
+  const validator = createDefaultMonokleValidator(parser);
+
+  await configureValidator(validator, {
+    'metadata/recommended-labels': false,
+    'metadata/custom-labels': 'err',
+    'metadata/custom-annotations': 'err'
+  });
+
+  Object.entries(validator.rules)[0][1].forEach(rule => {
+    if (rule.configuration.enabled) {
+      expect(rule.configurability).toBeDefined();
+    }
+  });
+});
+
+it('should generate dynamic configurable rules', async () => {
+  const parser = new ResourceParser();
+  const validator = createDefaultMonokleValidator(parser);
+
+  await configureValidator(validator, {
+    'metadata/recommended-labels': false,
+    'metadata/custom-labels': false,
+    'metadata/custom-annotations': false,
+    'metadata/app-annotation': 'err',
+    'metadata/hash-annotation': ['warn'],
+    'metadata/monokle.io__namespace-annotation': ['warn', ['minikube', 'kube-system']],
+  });
+
+  Object.entries(validator.rules)[0][1].forEach(rule => {
+    if (rule.configuration.enabled) {
+      expect(rule.configurability).toBeDefined();
+    }
+  });
+});
+
 async function processResourcesInFolder(path: string, rules?: RuleMap) {
   const files = await readDirectory(path);
   const resources = extractK8sResources(files);

--- a/packages/validation/src/__tests__/MonokleValidator.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.test.ts
@@ -210,7 +210,7 @@ it('should be valid SARIF', async () => {
 
   const validator = createDefaultMonokleValidator(parser);
   processRefs(resources, parser);
-  await configureValidator(validator);
+  await configureValidator(validator, {metadata: true});
   const response = await validator.validate({resources});
 
   const ajv = new Ajv({
@@ -234,13 +234,14 @@ it('should be valid SARIF', async () => {
   expect(validateSarif.errors?.length ?? 0).toBe(0);
 });
 
-function configureValidator(validator: MonokleValidator) {
+function configureValidator(validator: MonokleValidator, additionalPlugins: {[key: string]: boolean} = {}) {
   return validator.preload({
     plugins: {
       'yaml-syntax': true,
       'resource-links': true,
       'kubernetes-schema': true,
       'open-policy-agent': true,
+      ...additionalPlugins,
     },
     settings: {
       'kubernetes-schema': {

--- a/packages/validation/src/__tests__/MonokleValidator.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.test.ts
@@ -10,7 +10,7 @@ import {extractK8sResources, readDirectory} from './testUtils.js';
 import {ResourceRefType} from '../common/types.js';
 import {ResourceParser} from '../common/resourceParser.js';
 import {createDefaultMonokleValidator} from '../createDefaultMonokleValidator.node.js';
-import {SimpleCustomValidator} from '../node.js';
+import {RuleConfigurabilityType, SimpleCustomValidator} from '../node.js';
 import {defineRule} from '../custom.js';
 import {isDeployment} from '../validators/custom/schemas/deployment.apps.v1.js';
 
@@ -131,11 +131,16 @@ it('should allow rules to be configurable', async () => {
             advanced: {
               enabled: false,
               severity: 3,
+              configurability: {
+                type: RuleConfigurabilityType.Number,
+                name: 'Required replicas',
+                defaultValue: 1,
+              }
             },
             validate({resources, params}, {report}) {
               resources.filter(isDeployment).forEach(deployment => {
                 const replicaCount = deployment.spec?.replicas ?? 1;
-                const replicaThreshold = params ?? 1;
+                const replicaThreshold = params;
                 const valid = replicaCount > replicaThreshold;
                 if (valid) return;
                 report(deployment, {path: 'spec.replicas'});

--- a/packages/validation/src/__tests__/MonokleValidator.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.test.ts
@@ -10,7 +10,7 @@ import {extractK8sResources, readDirectory} from './testUtils.js';
 import {ResourceRefType} from '../common/types.js';
 import {ResourceParser} from '../common/resourceParser.js';
 import {createDefaultMonokleValidator} from '../createDefaultMonokleValidator.node.js';
-import {RuleConfigurabilityType, SimpleCustomValidator} from '../node.js';
+import {RuleConfigMetadataType, SimpleCustomValidator} from '../node.js';
 import {defineRule} from '../custom.js';
 import {isDeployment} from '../validators/custom/schemas/deployment.apps.v1.js';
 
@@ -131,8 +131,8 @@ it('should allow rules to be configurable', async () => {
             advanced: {
               enabled: false,
               severity: 3,
-              configurability: {
-                type: RuleConfigurabilityType.Number,
+              configMetadata: {
+                type: RuleConfigMetadataType.Number,
                 name: 'Required replicas',
                 defaultValue: 1,
               }

--- a/packages/validation/src/common/AbstractPlugin.ts
+++ b/packages/validation/src/common/AbstractPlugin.ts
@@ -193,7 +193,11 @@ export abstract class AbstractPlugin implements Plugin {
       const enabled =
         typeof severity === 'boolean' ? severity : typeof severity === 'string' ? true : defaultConfig.enabled;
       const level = typeof severity === 'string' ? (severity === 'err' ? 'error' : 'warning') : defaultConfig.level;
-      const parameters = config ?? defaultConfig.parameters;
+
+      const parameters = {
+        ...defaultConfig.parameters,
+        ...(config ? { configValue: config } : {})
+      };
 
       this._ruleConfig.set(ruleId, {
         ...defaultConfig,

--- a/packages/validation/src/common/sarif.ts
+++ b/packages/validation/src/common/sarif.ts
@@ -252,16 +252,15 @@ export type GitHubProperties = {
 };
 
 export enum RuleConfigurabilityType {
-  Number = 'number',
   String = 'string',
   StringArray = 'string[]',
+  Number = 'number',
   NumberArray = 'number[]',
 }
 
 export type RuleConfigurability = {
   type: RuleConfigurabilityType;
   name: string;
-  defaultValue: number | string | string[] | number[];
 }
 
 export type ValidationResult = {

--- a/packages/validation/src/common/sarif.ts
+++ b/packages/validation/src/common/sarif.ts
@@ -164,8 +164,10 @@ export type RuleConfig = {
 
   /**
    * The parameters for this rule.
+   *
+   * @see https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Ref508894764
    */
-  parameters?: any;
+  parameters?: PropertyBag & { configValue?: RuleConfigurabilityAllowedValues };
 };
 
 export type RuleLevel = 'warning' | 'error';
@@ -195,6 +197,13 @@ export type ValidationPolicyRule = {
   id: string;
   defaultConfiguration: RuleConfig;
 };
+
+/**
+ * Object like SARIF key-value type.
+ *
+ * @see https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Ref493408960
+ */
+export type PropertyBag = Record<string, any>;
 
 /**
  * These are custom properties used by GitHub.
@@ -249,11 +258,11 @@ export type GitHubProperties = {
   'security-severity'?: number;
 };
 
-export enum RuleConfigurabilityType {
-  String = 'string',
-  StringArray = 'string[]',
-  Number = 'number',
-  NumberArray = 'number[]',
+/**
+ * These are custom types related to the configurability of rules.
+ */
+export type RuleConfigurability = {
+  configurability?: RuleConfigurabilityProperties;
 };
 
 export type RuleConfigurabilityProperties = {
@@ -261,8 +270,13 @@ export type RuleConfigurabilityProperties = {
   name: string;
 };
 
-export type RuleConfigurability = {
-  configurability?: RuleConfigurabilityProperties;
+export type RuleConfigurabilityAllowedValues = string | string[] | number | number[];
+
+export enum RuleConfigurabilityType {
+  String = 'string',
+  StringArray = 'string[]',
+  Number = 'number',
+  NumberArray = 'number[]',
 };
 
 export type ValidationResult = {

--- a/packages/validation/src/common/sarif.ts
+++ b/packages/validation/src/common/sarif.ts
@@ -114,6 +114,8 @@ export type RuleMetadata<TProperties = {}> = {
   properties?: GitHubProperties & TProperties;
 
   relationships?: reportingDescriptorRelationship[];
+
+  configurability?: RuleConfigurability;
 };
 
 export type RelationshipKind = 'superset' | 'relevant';
@@ -248,6 +250,19 @@ export type GitHubProperties = {
    */
   'security-severity'?: number;
 };
+
+export enum RuleConfigurabilityType {
+  Number = 'number',
+  String = 'string',
+  StringArray = 'string[]',
+  NumberArray = 'number[]',
+}
+
+export type RuleConfigurability = {
+  type: RuleConfigurabilityType;
+  name: string;
+  defaultValue: number | string | string[] | number[];
+}
 
 export type ValidationResult = {
   ruleId: string;

--- a/packages/validation/src/common/sarif.ts
+++ b/packages/validation/src/common/sarif.ts
@@ -111,7 +111,7 @@ export type RuleMetadata<TProperties = {}> = {
   /**
    * Optional, custom properties
    */
-  properties?: GitHubProperties & RuleConfigurability & TProperties;
+  properties?: GitHubProperties & RuleConfigMetadata & TProperties;
 
   relationships?: reportingDescriptorRelationship[];
 };
@@ -167,7 +167,7 @@ export type RuleConfig = {
    *
    * @see https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Ref508894764
    */
-  parameters?: PropertyBag & { configValue?: RuleConfigurabilityAllowedValues };
+  parameters?: PropertyBag & { configValue?: RuleConfigMetadataAllowedValues };
 };
 
 export type RuleLevel = 'warning' | 'error';
@@ -259,20 +259,20 @@ export type GitHubProperties = {
 };
 
 /**
- * These are custom types related to the configurability of rules.
+ * These are custom types related to the config metadata of rules.
  */
-export type RuleConfigurability = {
-  configurability?: RuleConfigurabilityProperties;
+export type RuleConfigMetadata = {
+  configMetadata?: RuleConfigMetadataProperties;
 };
 
-export type RuleConfigurabilityProperties = {
-  type: RuleConfigurabilityType;
+export type RuleConfigMetadataProperties = {
+  type: RuleConfigMetadataType;
   name: string;
 };
 
-export type RuleConfigurabilityAllowedValues = string | string[] | number | number[];
+export type RuleConfigMetadataAllowedValues = string | string[] | number | number[];
 
-export enum RuleConfigurabilityType {
+export enum RuleConfigMetadataType {
   String = 'string',
   StringArray = 'string[]',
   Number = 'number',

--- a/packages/validation/src/common/sarif.ts
+++ b/packages/validation/src/common/sarif.ts
@@ -111,11 +111,9 @@ export type RuleMetadata<TProperties = {}> = {
   /**
    * Optional, custom properties
    */
-  properties?: GitHubProperties & TProperties;
+  properties?: GitHubProperties & RuleConfigurability & TProperties;
 
   relationships?: reportingDescriptorRelationship[];
-
-  configurability?: RuleConfigurability;
 };
 
 export type RelationshipKind = 'superset' | 'relevant';
@@ -256,12 +254,16 @@ export enum RuleConfigurabilityType {
   StringArray = 'string[]',
   Number = 'number',
   NumberArray = 'number[]',
-}
+};
 
-export type RuleConfigurability = {
+export type RuleConfigurabilityProperties = {
   type: RuleConfigurabilityType;
   name: string;
-}
+};
+
+export type RuleConfigurability = {
+  configurability?: RuleConfigurabilityProperties;
+};
 
 export type ValidationResult = {
   ruleId: string;

--- a/packages/validation/src/validators/custom/config.ts
+++ b/packages/validation/src/validators/custom/config.ts
@@ -1,5 +1,5 @@
 import type {Document, ParsedNode} from 'yaml';
-import {RuleConfigurability, RuleLevel, reportingDescriptorRelationship} from '../../node';
+import {RuleConfigurabilityProperties, RuleLevel, reportingDescriptorRelationship} from '../../node.js';
 
 export type PluginInit = {
   /**
@@ -122,7 +122,7 @@ export type RuleAdvancedInit = {
   level?: RuleLevel;
   severity?: number;
   relationships?: reportingDescriptorRelationship[];
-  configurability?: RuleConfigurability & {defaultValue?: string | string[] | number | number[]};
+  configurability?: RuleConfigurabilityProperties & {defaultValue?: string | string[] | number | number[]};
 };
 
 /**

--- a/packages/validation/src/validators/custom/config.ts
+++ b/packages/validation/src/validators/custom/config.ts
@@ -1,5 +1,5 @@
 import type {Document, ParsedNode} from 'yaml';
-import {RuleConfigurabilityProperties, RuleConfigurabilityAllowedValues, RuleLevel, reportingDescriptorRelationship} from '../../node.js';
+import {RuleConfigMetadataProperties, RuleConfigMetadataAllowedValues, RuleLevel, reportingDescriptorRelationship} from '../../node.js';
 
 export type PluginInit = {
   /**
@@ -122,7 +122,7 @@ export type RuleAdvancedInit = {
   level?: RuleLevel;
   severity?: number;
   relationships?: reportingDescriptorRelationship[];
-  configurability?: RuleConfigurabilityProperties & {defaultValue?: RuleConfigurabilityAllowedValues};
+  configMetadata?: RuleConfigMetadataProperties & {defaultValue?: RuleConfigMetadataAllowedValues};
 };
 
 /**

--- a/packages/validation/src/validators/custom/config.ts
+++ b/packages/validation/src/validators/custom/config.ts
@@ -122,7 +122,7 @@ export type RuleAdvancedInit = {
   level?: RuleLevel;
   severity?: number;
   relationships?: reportingDescriptorRelationship[];
-  configurability?: RuleConfigurability;
+  configurability?: RuleConfigurability & {defaultValue?: string | string[] | number | number[]};
 };
 
 /**

--- a/packages/validation/src/validators/custom/config.ts
+++ b/packages/validation/src/validators/custom/config.ts
@@ -1,5 +1,5 @@
 import type {Document, ParsedNode} from 'yaml';
-import {RuleConfigurabilityProperties, RuleLevel, reportingDescriptorRelationship} from '../../node.js';
+import {RuleConfigurabilityProperties, RuleConfigurabilityAllowedValues, RuleLevel, reportingDescriptorRelationship} from '../../node.js';
 
 export type PluginInit = {
   /**
@@ -122,7 +122,7 @@ export type RuleAdvancedInit = {
   level?: RuleLevel;
   severity?: number;
   relationships?: reportingDescriptorRelationship[];
-  configurability?: RuleConfigurabilityProperties & {defaultValue?: string | string[] | number | number[]};
+  configurability?: RuleConfigurabilityProperties & {defaultValue?: RuleConfigurabilityAllowedValues};
 };
 
 /**

--- a/packages/validation/src/validators/custom/config.ts
+++ b/packages/validation/src/validators/custom/config.ts
@@ -1,5 +1,5 @@
 import type {Document, ParsedNode} from 'yaml';
-import {RuleLevel, reportingDescriptorRelationship} from '../../node';
+import {RuleConfigurability, RuleLevel, reportingDescriptorRelationship} from '../../node';
 
 export type PluginInit = {
   /**
@@ -122,6 +122,7 @@ export type RuleAdvancedInit = {
   level?: RuleLevel;
   severity?: number;
   relationships?: reportingDescriptorRelationship[];
+  configurability?: RuleConfigurability;
 };
 
 /**

--- a/packages/validation/src/validators/custom/simpleValidator.ts
+++ b/packages/validation/src/validators/custom/simpleValidator.ts
@@ -59,7 +59,7 @@ export class SimpleCustomValidator extends AbstractPlugin {
             resources: dirtyResources,
             allResources: resources,
             settings: this._settings,
-            params: ruleConfig.parameters,
+            params: rule.configurability ? ruleConfig.parameters : undefined,
           },
           {
             parse: res => {
@@ -185,11 +185,13 @@ function toSarifRules(plugin: PluginInit): RuleMetadata[] {
       defaultConfiguration: {
         enabled: r.advanced?.enabled,
         level: r.advanced?.level,
+        parameters: r.advanced?.configurability?.defaultValue,
       },
       properties: {
         'security-severity': r.advanced?.severity,
       },
       relationships: r.advanced?.relationships,
+      configurability: r.advanced?.configurability,
     };
   });
 }

--- a/packages/validation/src/validators/custom/simpleValidator.ts
+++ b/packages/validation/src/validators/custom/simpleValidator.ts
@@ -59,7 +59,7 @@ export class SimpleCustomValidator extends AbstractPlugin {
             resources: dirtyResources,
             allResources: resources,
             settings: this._settings,
-            params: rule.properties?.configurability ? ruleConfig.parameters : undefined,
+            params: rule.properties?.configurability ? ruleConfig.parameters?.configValue : undefined,
           },
           {
             parse: res => {
@@ -185,7 +185,9 @@ function toSarifRules(plugin: PluginInit): RuleMetadata[] {
       defaultConfiguration: {
         enabled: r.advanced?.enabled,
         level: r.advanced?.level,
-        parameters: r.advanced?.configurability?.defaultValue,
+        parameters: {
+          configValue: r.advanced?.configurability?.defaultValue,
+        },
       },
       properties: {
         'security-severity': r.advanced?.severity,

--- a/packages/validation/src/validators/custom/simpleValidator.ts
+++ b/packages/validation/src/validators/custom/simpleValidator.ts
@@ -59,7 +59,7 @@ export class SimpleCustomValidator extends AbstractPlugin {
             resources: dirtyResources,
             allResources: resources,
             settings: this._settings,
-            params: rule.properties?.configurability ? ruleConfig.parameters?.configValue : undefined,
+            params: rule.properties?.configMetadata ? ruleConfig.parameters?.configValue : undefined,
           },
           {
             parse: res => {
@@ -186,15 +186,15 @@ function toSarifRules(plugin: PluginInit): RuleMetadata[] {
         enabled: r.advanced?.enabled,
         level: r.advanced?.level,
         parameters: {
-          configValue: r.advanced?.configurability?.defaultValue,
+          configValue: r.advanced?.configMetadata?.defaultValue,
         },
       },
       properties: {
         'security-severity': r.advanced?.severity,
-        configurability: r.advanced?.configurability
+        configMetadata: r.advanced?.configMetadata
         ? {
-          type: r.advanced.configurability.type,
-          name: r.advanced.configurability.name,
+          type: r.advanced.configMetadata.type,
+          name: r.advanced.configMetadata.name,
         }
       : undefined,
       },

--- a/packages/validation/src/validators/custom/simpleValidator.ts
+++ b/packages/validation/src/validators/custom/simpleValidator.ts
@@ -191,7 +191,12 @@ function toSarifRules(plugin: PluginInit): RuleMetadata[] {
         'security-severity': r.advanced?.severity,
       },
       relationships: r.advanced?.relationships,
-      configurability: r.advanced?.configurability,
+      configurability: r.advanced?.configurability
+        ? {
+          type: r.advanced.configurability.type,
+          name: r.advanced.configurability.name,
+        }
+      : undefined,
     };
   });
 }

--- a/packages/validation/src/validators/custom/simpleValidator.ts
+++ b/packages/validation/src/validators/custom/simpleValidator.ts
@@ -59,7 +59,7 @@ export class SimpleCustomValidator extends AbstractPlugin {
             resources: dirtyResources,
             allResources: resources,
             settings: this._settings,
-            params: rule.configurability ? ruleConfig.parameters : undefined,
+            params: rule.properties?.configurability ? ruleConfig.parameters : undefined,
           },
           {
             parse: res => {
@@ -189,14 +189,14 @@ function toSarifRules(plugin: PluginInit): RuleMetadata[] {
       },
       properties: {
         'security-severity': r.advanced?.severity,
-      },
-      relationships: r.advanced?.relationships,
-      configurability: r.advanced?.configurability
+        configurability: r.advanced?.configurability
         ? {
           type: r.advanced.configurability.type,
           name: r.advanced.configurability.name,
         }
       : undefined,
+      },
+      relationships: r.advanced?.relationships,
     };
   });
 }

--- a/packages/validation/src/validators/metadata/rules.ts
+++ b/packages/validation/src/validators/metadata/rules.ts
@@ -16,14 +16,16 @@ export const METADATA_RULES: RuleMetadata[] = [
     defaultConfiguration: {
       level: 'error',
       // Based on https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
-      parameters: [
-        'app.kubernetes.io/name',
-        'app.kubernetes.io/instance',
-        'app.kubernetes.io/version',
-        'app.kubernetes.io/component',
-        'app.kubernetes.io/part-of',
-        'app.kubernetes.io/managed',
-      ]
+      parameters: {
+        configValue: [
+          'app.kubernetes.io/name',
+          'app.kubernetes.io/instance',
+          'app.kubernetes.io/version',
+          'app.kubernetes.io/component',
+          'app.kubernetes.io/part-of',
+          'app.kubernetes.io/managed',
+        ]
+      },
     },
   },
   {
@@ -41,7 +43,9 @@ export const METADATA_RULES: RuleMetadata[] = [
     defaultConfiguration: {
       enabled: false,
       level: 'warning',
-      parameters: [],
+      parameters: {
+        configValue: [],
+      },
     },
     properties: {
       configurability: {
@@ -65,7 +69,9 @@ export const METADATA_RULES: RuleMetadata[] = [
     defaultConfiguration: {
       enabled: false,
       level: 'warning',
-      parameters: [],
+      parameters: {
+        configValue: [],
+      },
     },
     properties: {
       configurability: {

--- a/packages/validation/src/validators/metadata/rules.ts
+++ b/packages/validation/src/validators/metadata/rules.ts
@@ -1,4 +1,4 @@
-import {RuleMetadata} from '../../common/sarif.js';
+import {RuleConfigurabilityType, RuleMetadata} from '../../common/sarif.js';
 
 export const METADATA_RULES: RuleMetadata[] = [
   {
@@ -42,6 +42,11 @@ export const METADATA_RULES: RuleMetadata[] = [
       enabled: false,
       level: 'warning',
     },
+    configurability: {
+      type: RuleConfigurabilityType.StringArray,
+      name: 'Required labels',
+      defaultValue: [],
+    },
   },
   {
     id: 'MTD-custom-annotations',
@@ -58,6 +63,11 @@ export const METADATA_RULES: RuleMetadata[] = [
     defaultConfiguration: {
       enabled: false,
       level: 'warning',
+    },
+    configurability: {
+      type: RuleConfigurabilityType.StringArray,
+      name: 'Required annotations',
+      defaultValue: [],
     },
   },
 ];

--- a/packages/validation/src/validators/metadata/rules.ts
+++ b/packages/validation/src/validators/metadata/rules.ts
@@ -1,4 +1,4 @@
-import {RuleConfigurabilityType, RuleMetadata} from '../../common/sarif.js';
+import {RuleConfigMetadataType, RuleMetadata} from '../../common/sarif.js';
 
 export const METADATA_RULES: RuleMetadata[] = [
   {
@@ -48,8 +48,8 @@ export const METADATA_RULES: RuleMetadata[] = [
       },
     },
     properties: {
-      configurability: {
-        type: RuleConfigurabilityType.StringArray,
+      configMetadata: {
+        type: RuleConfigMetadataType.StringArray,
         name: 'Required labels',
       },
     },
@@ -74,8 +74,8 @@ export const METADATA_RULES: RuleMetadata[] = [
       },
     },
     properties: {
-      configurability: {
-        type: RuleConfigurabilityType.StringArray,
+      configMetadata: {
+        type: RuleConfigMetadataType.StringArray,
         name: 'Required annotations',
       },
     },

--- a/packages/validation/src/validators/metadata/rules.ts
+++ b/packages/validation/src/validators/metadata/rules.ts
@@ -41,11 +41,11 @@ export const METADATA_RULES: RuleMetadata[] = [
     defaultConfiguration: {
       enabled: false,
       level: 'warning',
+      parameters: [],
     },
     configurability: {
       type: RuleConfigurabilityType.StringArray,
       name: 'Required labels',
-      defaultValue: [],
     },
   },
   {
@@ -63,11 +63,11 @@ export const METADATA_RULES: RuleMetadata[] = [
     defaultConfiguration: {
       enabled: false,
       level: 'warning',
+      parameters: [],
     },
     configurability: {
       type: RuleConfigurabilityType.StringArray,
       name: 'Required annotations',
-      defaultValue: [],
     },
   },
 ];

--- a/packages/validation/src/validators/metadata/rules.ts
+++ b/packages/validation/src/validators/metadata/rules.ts
@@ -43,9 +43,11 @@ export const METADATA_RULES: RuleMetadata[] = [
       level: 'warning',
       parameters: [],
     },
-    configurability: {
-      type: RuleConfigurabilityType.StringArray,
-      name: 'Required labels',
+    properties: {
+      configurability: {
+        type: RuleConfigurabilityType.StringArray,
+        name: 'Required labels',
+      },
     },
   },
   {
@@ -65,9 +67,11 @@ export const METADATA_RULES: RuleMetadata[] = [
       level: 'warning',
       parameters: [],
     },
-    configurability: {
-      type: RuleConfigurabilityType.StringArray,
-      name: 'Required annotations',
+    properties: {
+      configurability: {
+        type: RuleConfigurabilityType.StringArray,
+        name: 'Required annotations',
+      },
     },
   },
 ];

--- a/packages/validation/src/validators/metadata/validator.ts
+++ b/packages/validation/src/validators/metadata/validator.ts
@@ -2,7 +2,7 @@ import difference from 'lodash/difference.js';
 import intersection from 'lodash/intersection.js';
 import {AbstractPlugin} from '../../common/AbstractPlugin.js';
 import {ResourceParser} from '../../common/resourceParser.js';
-import {ValidationResult} from '../../common/sarif.js';
+import {RuleConfigurabilityType, ValidationResult} from '../../common/sarif.js';
 import {Incremental, Resource} from '../../common/types.js';
 import {METADATA_RULES} from './rules.js';
 import {createLocations} from '../../utils/createLocations.js';
@@ -54,6 +54,11 @@ export class MetadataValidator extends AbstractPlugin {
         },
         defaultConfiguration: {
           parameters: {name: ruleNormalizedName}
+        },
+        configurability: {
+          type: RuleConfigurabilityType.StringArray,
+          name: `Allowed ${ruleTypeName} values`,
+          defaultValue: [],
         },
       });
     });

--- a/packages/validation/src/validators/metadata/validator.ts
+++ b/packages/validation/src/validators/metadata/validator.ts
@@ -2,7 +2,7 @@ import difference from 'lodash/difference.js';
 import intersection from 'lodash/intersection.js';
 import {AbstractPlugin} from '../../common/AbstractPlugin.js';
 import {ResourceParser} from '../../common/resourceParser.js';
-import {RuleConfigurabilityType, ValidationResult} from '../../common/sarif.js';
+import {RuleConfigMetadataType, ValidationResult} from '../../common/sarif.js';
 import {Incremental, Resource} from '../../common/types.js';
 import {METADATA_RULES} from './rules.js';
 import {createLocations} from '../../utils/createLocations.js';
@@ -56,8 +56,8 @@ export class MetadataValidator extends AbstractPlugin {
           parameters: {name: ruleNormalizedName}
         },
         properties: {
-          configurability: {
-            type: RuleConfigurabilityType.StringArray,
+          configMetadata: {
+            type: RuleConfigMetadataType.StringArray,
             name: `Allowed ${ruleTypeName} values`
           },
         }

--- a/packages/validation/src/validators/metadata/validator.ts
+++ b/packages/validation/src/validators/metadata/validator.ts
@@ -55,10 +55,12 @@ export class MetadataValidator extends AbstractPlugin {
         defaultConfiguration: {
           parameters: {name: ruleNormalizedName}
         },
-        configurability: {
-          type: RuleConfigurabilityType.StringArray,
-          name: `Allowed ${ruleTypeName} values`
-        },
+        properties: {
+          configurability: {
+            type: RuleConfigurabilityType.StringArray,
+            name: `Allowed ${ruleTypeName} values`
+          },
+        }
       });
     });
 

--- a/packages/validation/src/validators/metadata/validator.ts
+++ b/packages/validation/src/validators/metadata/validator.ts
@@ -96,7 +96,7 @@ export class MetadataValidator extends AbstractPlugin {
       invalidKeys = this.validateCustomAnnotations(resource, rule);
     } else if (rule.name.endsWith('-label') || rule.name.endsWith('-annotation')) {
       invalidKeys = this.validateDynamicRule(resource, rule);
-      expectedValues = rule.configuration?.parameters ?? [];
+      expectedValues = rule.configuration?.parameters?.configValue as string[] ?? [];
     }
 
     if (!invalidKeys.length) {
@@ -118,29 +118,29 @@ export class MetadataValidator extends AbstractPlugin {
   private validateRecommendedLabels(resource: Resource, rule: RuleMetadataWithConfig) {
     return this.validateMap(
       resource.content?.metadata?.labels,
-      rule.defaultConfiguration?.parameters
+      rule.defaultConfiguration?.parameters?.configValue as string[]
     );
   }
 
   private validateCustomLabels(resource: Resource, rule: RuleMetadataWithConfig) {
     return this.validateMap(
       resource.content?.metadata?.labels,
-      rule.configuration?.parameters
+      rule.configuration?.parameters?.configValue as string[]
     );
   }
 
   private validateCustomAnnotations(resource: Resource, rule: RuleMetadataWithConfig) {
     return this.validateMap(
       resource.content?.metadata?.annotations,
-      rule.configuration?.parameters
+      rule.configuration?.parameters?.configValue as string[]
     );
   }
 
   private validateDynamicRule(resource: Resource, rule: RuleMetadataWithConfig) {
     return this.validateMap(
       this.isLabelRule(rule.name) ? resource.content?.metadata?.labels : resource.content?.metadata?.annotations,
-      [rule.defaultConfiguration?.parameters?.name],
-      rule.configuration?.parameters
+      [rule.configuration?.parameters?.name],
+      rule.configuration?.parameters?.configValue as string[]
     );
   }
 

--- a/packages/validation/src/validators/metadata/validator.ts
+++ b/packages/validation/src/validators/metadata/validator.ts
@@ -57,8 +57,7 @@ export class MetadataValidator extends AbstractPlugin {
         },
         configurability: {
           type: RuleConfigurabilityType.StringArray,
-          name: `Allowed ${ruleTypeName} values`,
-          defaultValue: [],
+          name: `Allowed ${ruleTypeName} values`
         },
       });
     });


### PR DESCRIPTION
This PR fixes https://github.com/kubeshop/monokle-core/issues/397.

## Changes

- Introduced `configurability` field in rule definition to indicate for 3rd-parties that rule is configurable. This is required for any tools integrating with the library to  reason about rules and provide correct UI.

I'm not fully convinced about naming, we have `defaultConfiguration`, `configuration` and now `configurability`. Also `configruability` is a definition of how rule can be configured while values are passed via `configuration.parameters`, not sure if this shouldn't be merged somehow.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
