### PR TITLE
refactor: allow custom plugin loaders

### DIFF
--- a/.changeset/real-bikes-boil.md
+++ b/.changeset/real-bikes-boil.md
@@ -1,0 +1,5 @@
+---
+"@monokle/validation": patch
+---
+
+Added new customPluginLoader parameter

--- a/packages/validation/src/MonokleValidator.ts
+++ b/packages/validation/src/MonokleValidator.ts
@@ -12,8 +12,10 @@ import invariant from './utils/invariant.js';
 import {isDefined} from './utils/isDefined.js';
 import {NSA_TAXONOMY} from './taxonomies/nsa.js';
 import {CIS_TAXONOMY} from './taxonomies/cis.js';
+import {ResourceParser} from './common/resourceParser.js';
 
 export type PluginLoader = (name: string) => Promise<Plugin>;
+export type CustomPluginLoader = (name: string, parser: ResourceParser) => Promise<Plugin>;
 
 export function createMonokleValidator(loader: PluginLoader, fallback?: PluginMap) {
   return new MonokleValidator(loader, fallback);

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -3,6 +3,8 @@
  */
 export * from './commonExports.js';
 
+export * from './pluginLoaders/index.js';
+
 export * from './createExtensibleMonokleValidator.browser.js';
 export * from './createDefaultMonokleValidator.browser.js';
 export * from './config/index.browser.js';

--- a/packages/validation/src/node.ts
+++ b/packages/validation/src/node.ts
@@ -3,6 +3,8 @@
  */
 export * from './commonExports.js';
 
+export * from './pluginLoaders/index.node.js';
+
 export * from './createExtensibleMonokleValidator.node.js';
 export * from './createDefaultMonokleValidator.node.js';
 export * from './config/index.node.js';

--- a/packages/validation/src/pluginLoaders/dynamicImportLoader.ts
+++ b/packages/validation/src/pluginLoaders/dynamicImportLoader.ts
@@ -1,0 +1,12 @@
+import {CustomPluginLoader} from '../MonokleValidator.js';
+import {SimpleCustomValidator} from '../validators/custom/simpleValidator.js';
+
+export const dynamicImportCustomPluginLoader: CustomPluginLoader = async (pluginName, parser) => {
+  try {
+    const url = `https://plugins.monokle.com/validation/${pluginName}/latest.js`;
+    const customPlugin = await import(/* @vite-ignore */ url);
+    return new SimpleCustomValidator(customPlugin.default, parser);
+  } catch (err) {
+    throw new Error(err instanceof Error ? `plugin_not_found: ${err.message}` : `plugin_not_found: ${String(err)}`);
+  }
+};

--- a/packages/validation/src/pluginLoaders/index.node.ts
+++ b/packages/validation/src/pluginLoaders/index.node.ts
@@ -1,0 +1,2 @@
+export * from './dynamicImportLoader.js';
+export * from './requireFromStringLoader.node.js';

--- a/packages/validation/src/pluginLoaders/index.ts
+++ b/packages/validation/src/pluginLoaders/index.ts
@@ -1,0 +1,1 @@
+export * from './dynamicImportLoader.js';

--- a/packages/validation/src/pluginLoaders/requireFromStringLoader.node.ts
+++ b/packages/validation/src/pluginLoaders/requireFromStringLoader.node.ts
@@ -1,0 +1,12 @@
+import {CustomPluginLoader} from '../MonokleValidator.js';
+import {loadCustomPlugin} from '../utils/loadCustomPlugin.node.js';
+import {SimpleCustomValidator} from '../validators/custom/simpleValidator.js';
+
+export const requireFromStringCustomPluginLoader: CustomPluginLoader = async (pluginName, parser) => {
+  try {
+    const customPlugin = await loadCustomPlugin(pluginName);
+    return new SimpleCustomValidator(customPlugin, parser);
+  } catch (err) {
+    throw new Error(`plugin_not_found: $err`);
+  }
+};


### PR DESCRIPTION
The reason for this PR is that we need to be able to customize the loading of plugins on Desktop in order to retrieve them from `<userDataDir>/validationPlugins `

## Changes

- customPluginLoader can be specified when creating a new extensible validator to customize how plugins are retrieved
- exported the already implemented plugin loaders 

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
