### PR TITLE
fix(validation): add flag to indicate dynamic rules

### DIFF
--- a/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.metadata.test.ts
@@ -193,6 +193,7 @@ it('should have custom-* configurable rules', async () => {
   Object.entries(validator.rules)[0][1].forEach(rule => {
     if (rule.configuration.enabled) {
       expect(rule.properties?.configMetadata).toBeDefined();
+      expect(rule.configuration.parameters?.dynamic).toBeUndefined();
     }
   });
 });
@@ -213,6 +214,7 @@ it('should generate dynamic configurable rules', async () => {
   Object.entries(validator.rules)[0][1].forEach(rule => {
     if (rule.configuration.enabled) {
       expect(rule.properties?.configMetadata).toBeDefined();
+      expect(rule.configuration.parameters?.dynamic).toBe(true);
     }
   });
 });

--- a/packages/validation/src/common/sarif.ts
+++ b/packages/validation/src/common/sarif.ts
@@ -167,7 +167,7 @@ export type RuleConfig = {
    *
    * @see https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Ref508894764
    */
-  parameters?: PropertyBag & { configValue?: RuleConfigMetadataAllowedValues };
+  parameters?: PropertyBag & { configValue?: RuleConfigMetadataAllowedValues, dynamic?: boolean };
 };
 
 export type RuleLevel = 'warning' | 'error';

--- a/packages/validation/src/validators/metadata/validator.ts
+++ b/packages/validation/src/validators/metadata/validator.ts
@@ -53,7 +53,10 @@ export class MetadataValidator extends AbstractPlugin {
           text: `Add required ${ruleTypeName}. You can hover the key for documentation.`
         },
         defaultConfiguration: {
-          parameters: {name: ruleNormalizedName}
+          parameters: {
+            name: ruleNormalizedName,
+            dynamic: true,
+          }
         },
         properties: {
           configMetadata: {


### PR DESCRIPTION
This PR introduces `rule.config.parameters.dynamic` flag. This is used to indicate that the rule is dynamic so special interaction (like removing) can be used with such rules.

## Changes

- Introduced `dynamic` flag.

## Fixes

- None.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
