### PR TITLE
fix(validation): add 'toolComponent.index' in SARIF output

### DIFF
--- a/.changeset/cool-emus-destroy.md
+++ b/.changeset/cool-emus-destroy.md
@@ -1,0 +1,5 @@
+---
+"@monokle/validation": patch
+---
+
+Add missing '...toolComponent.index' to SARIF output

--- a/packages/validation/src/MonokleValidator.ts
+++ b/packages/validation/src/MonokleValidator.ts
@@ -257,6 +257,8 @@ export class MonokleValidator implements Validator {
       extensions: validators.map(v => v.toolComponent),
     };
 
+    validators.forEach((v, index) => v.toolComponentIndex = index);
+
     await nextTick();
     throwIfAborted(loadAbortSignal, externalAbortSignal);
 

--- a/packages/validation/src/common/AbstractPlugin.ts
+++ b/packages/validation/src/common/AbstractPlugin.ts
@@ -17,6 +17,7 @@ export abstract class AbstractPlugin implements Plugin {
   protected _metadata: PluginMetadata;
   public configured = false;
 
+  protected _toolComponentIndex: number = -1;
   protected _enabled: boolean = true;
 
   protected _rules: RuleMetadata[] = [];
@@ -61,6 +62,14 @@ export abstract class AbstractPlugin implements Plugin {
     const name = this.name;
     const rules = this._rules;
     return {name, rules};
+  }
+
+  get toolComponentIndex(): number {
+    return this._toolComponentIndex;
+  }
+
+  set toolComponentIndex(value: number) {
+    this._toolComponentIndex = value;
   }
 
   get name(): string {
@@ -133,6 +142,7 @@ export abstract class AbstractPlugin implements Plugin {
         index: index ?? 0,
         toolComponent: {
           name: this.name,
+          index: this.toolComponentIndex,
         },
       },
       taxa,

--- a/packages/validation/src/common/sarif.ts
+++ b/packages/validation/src/common/sarif.ts
@@ -309,6 +309,7 @@ export type ValidationResult = {
  */
 export type ToolComponentReference = {
   name: string;
+  index: number;
 };
 
 /**

--- a/packages/validation/src/common/types.ts
+++ b/packages/validation/src/common/types.ts
@@ -190,6 +190,12 @@ export interface Plugin {
   get toolComponent(): ToolPlugin;
 
   /**
+   * The SARIF tool component index.
+   */
+  get toolComponentIndex(): number;
+  set toolComponentIndex(value: number);
+
+  /**
    * The rules of this plugin.
    */
   get rules(): RuleMetadataWithConfig[];

--- a/packages/validation/src/utils/getRule.ts
+++ b/packages/validation/src/utils/getRule.ts
@@ -18,8 +18,10 @@ export function getRuleForResult(response: ValidationResponse, result: Validatio
 }
 
 export function getRuleForResultV2(run: ValidationRun | undefined, result: ValidationResult): RuleMetadata {
+  const toolPluginIndex = result.rule.toolComponent.index;
   const toolPluginName = result.rule.toolComponent.name;
-  const plugin = run?.tool.extensions?.find(plugin => plugin.name === toolPluginName);
+  const extensions = run?.tool.extensions ?? [];
+  const plugin = extensions[toolPluginIndex] ?? extensions.find(plugin => plugin.name === toolPluginName);
   const ruleIndex = result.rule.index;
   const rule = plugin?.rules[ruleIndex];
   invariant(rule, 'rule not found');


### PR DESCRIPTION
This PR fixes #428.

## Changes

- Added `results.rule.toolComponent.index` field to SARIF output. See https://github.com/kubeshop/monokle-core/issues/428#issuecomment-1614450736 for broader explanation and how it's compliant with SARIF specs.
- I still kept matching by name as a fallback.

## Fixes

- Same as `Changes`.

Confirmed that output is now correctly read by SARIF VSC extension with rules metadata filled:

![image](https://github.com/kubeshop/monokle-core/assets/1061942/47976ee4-4431-4a57-870c-d749ae37b198)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
