### PR TITLE
Make toolComponent.index optional

### DIFF
--- a/.changeset/ninety-ways-pump.md
+++ b/.changeset/ninety-ways-pump.md
@@ -1,0 +1,5 @@
+---
+"@monokle/validation": patch
+---
+
+Make '...toolComponent.index' optional

--- a/packages/validation/src/common/sarif.ts
+++ b/packages/validation/src/common/sarif.ts
@@ -309,7 +309,7 @@ export type ValidationResult = {
  */
 export type ToolComponentReference = {
   name: string;
-  index: number;
+  index?: number;
 };
 
 /**

--- a/packages/validation/src/utils/getRule.ts
+++ b/packages/validation/src/utils/getRule.ts
@@ -21,7 +21,7 @@ export function getRuleForResultV2(run: ValidationRun | undefined, result: Valid
   const toolPluginIndex = result.rule.toolComponent.index;
   const toolPluginName = result.rule.toolComponent.name;
   const extensions = run?.tool.extensions ?? [];
-  const plugin = extensions[toolPluginIndex] ?? extensions.find(plugin => plugin.name === toolPluginName);
+  const plugin = toolPluginIndex && extensions[toolPluginIndex] ? extensions.find(plugin => plugin.name === toolPluginName) : undefined;
   const ruleIndex = result.rule.index;
   const rule = plugin?.rules[ruleIndex];
   invariant(rule, 'rule not found');

--- a/packages/validation/src/validators/custom/devValidator.ts
+++ b/packages/validation/src/validators/custom/devValidator.ts
@@ -29,6 +29,7 @@ export class DevCustomValidator implements Plugin {
     settings?: any;
   };
   private _debug: boolean = false;
+  protected _toolComponentIndex: number = -1;
 
   constructor(private parser: ResourceParser) {
     this.hmr();
@@ -122,6 +123,14 @@ export class DevCustomValidator implements Plugin {
     }
 
     return this._currentValidator.toolComponent;
+  }
+
+  get toolComponentIndex(): number {
+    return this._toolComponentIndex;
+  }
+
+  set toolComponentIndex(value: number) {
+    this._toolComponentIndex = value;
   }
 
   get rules(): RuleMetadataWithConfig[] {


### PR DESCRIPTION
This PR fixes bug introduced in #429 and https://github.com/kubeshop/monokle-core/actions/runs/5444228698/jobs/9901781322#step:5:35.

## Changes

- Made `toolComponent.index` optional.

## Fixes

- Same as above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
