### PR TITLE
ci: run build for PRs targeting main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
This PR adds build script to be run for all pull requests targeting `main` branch.

The context for this change is that I broke release job recently because build failed (which I haven't checked locally 🙈), https://github.com/kubeshop/monokle-core/actions/runs/5444228698/jobs/9901781322#step:5:35.  With this simple check it would not have happened.

## Changes

- As above.

## Fixes

- None.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
