### PR TITLE
fix(validation): add settings to Zod config schema for 'readConfig()'

### DIFF
--- a/.changeset/strange-teachers-smoke.md
+++ b/.changeset/strange-teachers-smoke.md
@@ -1,0 +1,5 @@
+---
+"@monokle/validation": patch
+---
+
+Fixed 'readConfig()' function to parse settings

--- a/packages/validation/src/__tests__/MonokleValidator.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.test.ts
@@ -10,7 +10,7 @@ import {extractK8sResources, readDirectory} from './testUtils.js';
 import {ResourceRefType} from '../common/types.js';
 import {ResourceParser} from '../common/resourceParser.js';
 import {createDefaultMonokleValidator} from '../createDefaultMonokleValidator.node.js';
-import {RuleConfigMetadataType, SimpleCustomValidator} from '../node.js';
+import {RuleConfigMetadataType, SimpleCustomValidator, readConfig} from '../node.js';
 import {defineRule} from '../custom.js';
 import {isDeployment} from '../validators/custom/schemas/deployment.apps.v1.js';
 
@@ -232,6 +232,29 @@ it('should be valid SARIF', async () => {
   });
 
   expect(validateSarif.errors?.length ?? 0).toBe(0);
+});
+
+it('should correctly read config file #1', async () => {
+  const config = await readConfig('src/__tests__/resources/config1.yaml');
+
+  expect(config).toHaveProperty('plugins');
+  expect(config).toHaveProperty('settings');
+
+  const ks = (config?.settings ?? {})['kubernetes-schema'];
+  expect(ks?.schemaVersion).toBe('v1.27.1');
+});
+
+it('should correctly read config file #2', async () => {
+  const config = await readConfig('src/__tests__/resources/config2.yaml');
+
+  expect(config).toHaveProperty('plugins');
+  expect(config).toHaveProperty('rules');
+
+  const rule1 = (config?.rules ?? {})['open-policy-agent/no-elevated-process'];
+  expect(rule1).toBe(false);
+
+  const rule2 = (config?.rules ?? {})['open-policy-agent/no-sys-admin'];
+  expect(rule2).toBe(true);
 });
 
 function configureValidator(validator: MonokleValidator, additionalPlugins: {[key: string]: boolean} = {}) {

--- a/packages/validation/src/__tests__/resources/config1.yaml
+++ b/packages/validation/src/__tests__/resources/config1.yaml
@@ -1,0 +1,8 @@
+plugins:
+  yaml-syntax: false
+  open-policy-agent: false
+  kubernetes-schema: true
+  pod-security-standards: true
+settings:
+  kubernetes-schema:
+    schemaVersion: v1.27.1

--- a/packages/validation/src/__tests__/resources/config2.yaml
+++ b/packages/validation/src/__tests__/resources/config2.yaml
@@ -1,0 +1,8 @@
+plugins:
+  open-policy-agent: true
+  yaml-syntax: true
+rules:
+  open-policy-agent/no-elevated-process: false
+  open-policy-agent/app-armor: false
+  open-policy-agent/drop-capabilities: false
+  open-policy-agent/no-sys-admin: true

--- a/packages/validation/src/config/parse.ts
+++ b/packages/validation/src/config/parse.ts
@@ -25,7 +25,7 @@ export type PluginMap = Record<string, boolean>;
 export type Config = {
   plugins?: PluginMap;
   rules?: RuleMap;
-  settings?: any;
+  settings?: Record<string, any>;
 };
 
 export const configSchema: ZodType<Config> = z.object({
@@ -33,6 +33,7 @@ export const configSchema: ZodType<Config> = z.object({
   version: z.string().optional(),
   plugins: z.record(z.boolean()).optional(),
   rules: z.record(z.boolean().or(z.enum(['warn', 'err']))).optional(),
+  settings: z.record(z.any()).optional(),
 });
 
 /**


### PR DESCRIPTION
This PR fixes #435.

## Changes

- None.

## Fixes

- Fixed Zod config schema to include `settings` section.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
