### PR TITLE
fix(validation): fix getRule toolComponent index check

### DIFF
--- a/.changeset/twelve-chicken-walk.md
+++ b/.changeset/twelve-chicken-walk.md
@@ -1,0 +1,5 @@
+---
+"@monokle/validation": patch
+---
+
+Fix `toolComponent` index check in `getRuleForResultV2()` function

--- a/packages/validation/src/utils/getRule.ts
+++ b/packages/validation/src/utils/getRule.ts
@@ -18,10 +18,10 @@ export function getRuleForResult(response: ValidationResponse, result: Validatio
 }
 
 export function getRuleForResultV2(run: ValidationRun | undefined, result: ValidationResult): RuleMetadata {
-  const toolPluginIndex = result.rule.toolComponent.index;
+  const toolPluginIndex = result.rule.toolComponent.index ?? -1;
   const toolPluginName = result.rule.toolComponent.name;
   const extensions = run?.tool.extensions ?? [];
-  const plugin = toolPluginIndex && extensions[toolPluginIndex] ? extensions.find(plugin => plugin.name === toolPluginName) : undefined;
+  const plugin = extensions[toolPluginIndex] ?? extensions.find(plugin => plugin.name === toolPluginName);
   const ruleIndex = result.rule.index;
   const rule = plugin?.rules[ruleIndex];
   invariant(rule, 'rule not found');


### PR DESCRIPTION
This PR fixes invalid check which was false for `0` index while it should be `true`.

The initial idea (from #429) was to still keep matching by name as fallback. And it get broken in #432.

So instead of changing to:

```ts
const plugin = isDefined(toolPluginIndex) ? extensions[toolPluginIndex] : extensions.find(plugin => plugin.name === toolPluginName);
```

which would again lost a purpose of name check fallback, I changed it as in the code - to always have numeric index and then use it for getting plugin with `??` for fallback name check.

## Changes

- As described above.

## Fixes

- As described above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
