### PR TITLE
fix: support kustomize patches with only a Scalar path

### DIFF
--- a/packages/validation/src/__tests__/MonokleValidator.test.ts
+++ b/packages/validation/src/__tests__/MonokleValidator.test.ts
@@ -77,6 +77,11 @@ it('should support patches and additionalValuesFiles', async () => {
   expect(hasErrors).toBe(2);
 });
 
+it('should support Kustomize Components', async () => {
+  const {resources, response} = await processResourcesInFolder('src/__tests__/resources/kustomize-components');
+  expect( resources.length ).toBe( 3 );
+});
+
 it('should support ownerRefs', async () => {
   const {resources, response} = await processResourcesInFolder('src/__tests__/resources/owner-references');
 

--- a/packages/validation/src/__tests__/resources/kustomize-components/components/without-loadgenerator/delete-loadgenerator.patch.yaml
+++ b/packages/validation/src/__tests__/resources/kustomize-components/components/without-loadgenerator/delete-loadgenerator.patch.yaml
@@ -1,0 +1,5 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadgenerator
+$patch: delete

--- a/packages/validation/src/__tests__/resources/kustomize-components/components/without-loadgenerator/kustomization.yaml
+++ b/packages/validation/src/__tests__/resources/kustomize-components/components/without-loadgenerator/kustomization.yaml
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+- delete-loadgenerator.patch.yaml

--- a/packages/validation/src/__tests__/resources/kustomize-components/kustomization.yaml
+++ b/packages/validation/src/__tests__/resources/kustomize-components/kustomization.yaml
@@ -1,0 +1,20 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- base
+components:
+ - components/without-loadgenerator

--- a/packages/validation/src/constants.ts
+++ b/packages/validation/src/constants.ts
@@ -16,6 +16,7 @@ export const FALLBACK_REGION: Region = {
 };
 
 export const KUSTOMIZATION_KIND = 'Kustomization';
+export const KUSTOMIZATION_COMPONENT_KIND = 'Component';
 export const KUSTOMIZATION_API_GROUP = 'kustomize.config.k8s.io';
 export const CORE_PLUGINS = [
   'pod-security-standards',

--- a/packages/validation/src/references/utils/kustomizeRefs.ts
+++ b/packages/validation/src/references/utils/kustomizeRefs.ts
@@ -3,7 +3,7 @@ import {isScalar, isSeq} from 'yaml';
 import {NodeWrapper} from '../../common/NodeWrapper.js';
 import {ResourceParser} from '../../common/resourceParser.js';
 import {Resource, ResourceRef, ResourceRefType} from '../../common/types.js';
-import {KUSTOMIZATION_API_GROUP, KUSTOMIZATION_KIND} from '../../constants.js';
+import { KUSTOMIZATION_API_GROUP, KUSTOMIZATION_COMPONENT_KIND, KUSTOMIZATION_KIND } from "../../constants.js";
 import {linkResources} from './createResourceRef.js';
 import {findChildren, findResourceById, getResourcesForPath, isFolderPath} from './helpers.js';
 
@@ -33,7 +33,9 @@ function linkParentKustomization(
  */
 
 export function isKustomizationResource(r: Resource | undefined) {
-  return r && r.kind === KUSTOMIZATION_KIND && (!r.apiVersion || r.apiVersion.startsWith(KUSTOMIZATION_API_GROUP));
+  return r &&
+    (r.kind === KUSTOMIZATION_KIND || r.kind === KUSTOMIZATION_COMPONENT_KIND) &&
+    (!r.apiVersion || r.apiVersion.startsWith(KUSTOMIZATION_API_GROUP));
 }
 
 /**
@@ -254,12 +256,17 @@ export function getScalarNodes(resource: Resource, nodePath: string, parser: Res
     const name = names[ix];
 
     parents.forEach(parent => {
-      const child = parent.get(name, true);
-      if (child) {
-        if (isSeq<any>(child)) {
-          nextParents = nextParents.concat(child.items);
-        } else {
-          nextParents.push(child);
+      if( isScalar( parent )){
+         nextParents.push( parent );
+      }
+      else {
+        const child = parent.get(name, true);
+        if (child) {
+          if (isSeq<any>(child)) {
+            nextParents = nextParents.concat(child.items);
+          } else {
+            nextParents.push(child);
+          }
         }
       }
     });


### PR DESCRIPTION
This PR fixes parsing of direct patch references like the following:

```
patches:
- delete-loadgenerator.patch.yaml
```


## Changes

-

## Fixes

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [X]  added a test
