### PR TITLE
feat: add SARIF fingerprints & baseline

### DIFF
--- a/packages/validation/src/MonokleValidator.ts
+++ b/packages/validation/src/MonokleValidator.ts
@@ -32,6 +32,35 @@ const DEFAULT_PLUGIN_MAP = {
   'kubernetes-schema': true,
 };
 
+type ValidateParams = {
+  /**
+   * The resources that will be validated.
+   */
+  resources: Resource[];
+
+  /**
+   * The list of resources that recently got updated.
+   *
+   * @remarks Validators can use this information to skip non-modified resources.
+   */
+  incremental?: Incremental;
+
+  /**
+   * A previous run which acts as the baseline for detected problems.
+   *
+   * @remark Providing a baseline will set run.baselineGuid and result.baselineStatus.
+   * @remark Newly fixed problems will be added as 'absent' results.
+   * When using baseline, it is important to properly filter or
+   * indicate absent results or they appear as false positives.
+   */
+  baseline?: ValidationResponse;
+
+  /**
+   * A signal that can be used to abort processing.
+   */
+  abortSignal?: AbortSignal;
+};
+
 export class MonokleValidator implements Validator {
   /**
    * The user configuration of this validator.
@@ -241,12 +270,7 @@ export class MonokleValidator implements Validator {
     incremental,
     baseline,
     abortSignal: externalAbortSignal,
-  }: {
-    resources: Resource[];
-    incremental?: Incremental;
-    baseline?: ValidationResponse;
-    abortSignal?: AbortSignal;
-  }): Promise<ValidationResponse> {
+  }: ValidateParams): Promise<ValidationResponse> {
     if (this._loading === undefined) {
       this.load();
     }

--- a/packages/validation/src/__tests__/sarif/assets/deployment.yaml
+++ b/packages/validation/src/__tests__/sarif/assets/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: demo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: demo
+    spec:
+      containers:
+        - name: demo
+          image: demo:latest

--- a/packages/validation/src/__tests__/sarif/fingerprint.test.ts
+++ b/packages/validation/src/__tests__/sarif/fingerprint.test.ts
@@ -1,0 +1,61 @@
+import 'isomorphic-fetch';
+import {expect, it} from 'vitest';
+import {createDefaultMonokleValidator} from '../../index.js';
+
+import {PRACTICES_ALL_DISABLED, extractK8sResources, readDirectory} from '../testUtils.js';
+
+it('should have fingerprints & baseline', async () => {
+  const validator = createDefaultMonokleValidator();
+
+  await validator.preload({
+    plugins: {
+      practices: true,
+    },
+    rules: {
+      ...PRACTICES_ALL_DISABLED,
+      'practices/no-writable-fs': 'err',
+      'practices/no-latest-image': 'err',
+    },
+  });
+
+  const files = await readDirectory('./src/__tests__/sarif/assets');
+  const resourceBad = extractK8sResources(files);
+  const badResponse = await validator.validate({resources: resourceBad});
+
+  // Enable another rule to have one "new" problem
+  await validator.preload({
+    plugins: {
+      practices: true,
+    },
+    rules: {
+      ...PRACTICES_ALL_DISABLED,
+      'practices/no-writable-fs': 'err',
+      'practices/no-latest-image': 'err',
+      'practices/drop-capabilities': 'err',
+    },
+  });
+
+  // Fix no-latest-image problem to have one "absent" problem
+  files[0].content = files[0].content.replace(':latest', ':v1');
+
+  const editedResponse = await validator.validate({
+    resources: extractK8sResources(files),
+    incremental: {resourceIds: [resourceBad[0].id]},
+    baseline: badResponse,
+  });
+
+  editedResponse.runs.forEach(r =>
+    r.results.forEach(result => {
+      console.error(result.ruleId, result.fingerprints?.['monokleHash/v1']);
+    })
+  );
+
+  const run = editedResponse.runs[0];
+  expect(run.baselineGuid).toBeDefined();
+  const unchangedCount = run.results.reduce((sum, r) => sum + (r.baselineState === 'unchanged' ? 1 : 0), 0);
+  const newCount = run.results.reduce((sum, r) => sum + (r.baselineState === 'new' ? 1 : 0), 0);
+  const absentCount = run.results.reduce((sum, r) => sum + (r.baselineState === 'absent' ? 1 : 0), 0);
+  expect(unchangedCount).toBe(1);
+  expect(newCount).toBe(1);
+  expect(absentCount).toBe(1);
+});

--- a/packages/validation/src/__tests__/testUtils.ts
+++ b/packages/validation/src/__tests__/testUtils.ts
@@ -5,7 +5,7 @@ import {readFile as readFileFromFs} from 'fs/promises';
 import chunkArray from 'lodash/chunk.js';
 import {LineCounter, parseAllDocuments, parseDocument} from 'yaml';
 import {Resource, ValidationResult} from '../index.js';
-import { expect } from 'vitest';
+import {expect} from 'vitest';
 
 export const KUSTOMIZATION_KIND = 'Kustomization';
 export const KUSTOMIZATION_API_GROUP = 'kustomize.config.k8s.io';
@@ -202,3 +202,17 @@ export function expectResult(result: ValidationResult, ruleId: string, level: st
   expect(result.level).toBe(level);
   expect(result.message.text).toContain(resource);
 }
+
+export const PRACTICES_ALL_DISABLED = {
+  'practices/no-latest-image': false,
+  'practices/no-sys-admin': false,
+  'practices/no-mounted-docker-sock': false,
+  'practices/no-writable-fs': false,
+  'practices/drop-capabilities': false,
+  'practices/no-low-user-id': false,
+  'practices/no-low-group-id': false,
+  'practices/no-automounted-service-account-token': false,
+  'practices/no-pod-create': false,
+  'practices/no-pod-execute': false,
+  'practices/no-root-group': false,
+};

--- a/packages/validation/src/common/sarif.ts
+++ b/packages/validation/src/common/sarif.ts
@@ -15,6 +15,8 @@ export type ValidationRun = {
   invocations?: ValidationInvocation[];
   results: ValidationResult[];
   taxonomies?: Taxonomy[];
+  automationDetails: RunAutomationDetails;
+  baselineGuid?: string;
 };
 
 /**
@@ -40,6 +42,10 @@ export type Taxon = {
 export type Tool = {
   driver: ToolComponent;
   extensions?: ToolPlugin[];
+};
+
+export type RunAutomationDetails = {
+  guid: string;
 };
 
 /**
@@ -170,7 +176,7 @@ export type RuleConfig = {
    *
    * @see https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Ref508894764
    */
-  parameters?: PropertyBag & { configValue?: RuleConfigMetadataAllowedValues, dynamic?: boolean };
+  parameters?: PropertyBag & {configValue?: RuleConfigMetadataAllowedValues; dynamic?: boolean};
 };
 
 export type RuleLevel = 'warning' | 'error';
@@ -280,7 +286,7 @@ export enum RuleConfigMetadataType {
   StringArray = 'string[]',
   Number = 'number',
   NumberArray = 'number[]',
-};
+}
 
 export type ValidationResult = {
   ruleId: string;
@@ -290,6 +296,8 @@ export type ValidationResult = {
   message: {
     text: string;
   };
+  fingerprints?: FingerPrints;
+  baselineState?: BaseLineState;
 
   /**
    * The location of the error.
@@ -302,6 +310,17 @@ export type ValidationResult = {
    * @hint use getFileLocation and getResourceLocation from utils/sarif.ts
    */
   locations: [Location, Location];
+};
+
+export type BaseLineState = 'new' | 'unchanged' | 'updated' | 'absent';
+
+/**
+ * Fingerprints provide stable identifiers for results based on evolving hashing algorithms.
+ *
+ * @see https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc10541092
+ */
+export type FingerPrints = {
+  'monokleHash/v1': string;
 };
 
 /**
@@ -340,8 +359,14 @@ export type Region = {
   endColumn: number;
 };
 
-export type LogicalLocation = {
-  kind: 'resource';
-  name?: string;
-  fullyQualifiedName?: string;
-};
+export type LogicalLocation =
+  | {
+      kind: 'resource'; // custom value for our split resources
+      name?: string; // the name of the resource
+      fullyQualifiedName?: string; // the name with file
+    }
+  | {
+      kind: 'element'; // recommended value for location within XML or HTML documents
+      name?: string; // the property at the leaf of the path
+      fullyQualifiedName?: string; // the full path
+    };

--- a/packages/validation/src/common/types.ts
+++ b/packages/validation/src/common/types.ts
@@ -3,7 +3,9 @@ import {RuleMap} from '../config/parse.js';
 import {PluginMetadataWithConfig, RuleMetadataWithConfig} from '../types.js';
 import {ResourceSchema} from '../validators/kubernetes-schema/schemaLoader.js';
 import {ResourceParser} from './resourceParser.js';
-import {ToolPlugin, ValidationPolicy, ValidationResult, ValidationRun} from './sarif.js';
+import {ToolPlugin, ValidationPolicy, ValidationResult} from './sarif.js';
+
+export type YamlPath = Array<string | number>;
 
 /* * * * * * * * * * * * * * * * *
  * The common resource type

--- a/packages/validation/src/config/parse.ts
+++ b/packages/validation/src/config/parse.ts
@@ -16,6 +16,9 @@ export type RuleValue = PrimitiveRuleValue | ArrayRuleValue | ObjectRuleValue;
 export type PrimitiveRuleValue = boolean | 'warn' | 'err' | undefined;
 export type ArrayRuleValue = [PrimitiveRuleValue] | [PrimitiveRuleValue, any];
 export type ObjectRuleValue = {severity: PrimitiveRuleValue; config: any};
+export type Settings = Record<string, any> & {
+  debug?: boolean;
+};
 
 /**
  * The validators that will be loaded.
@@ -25,7 +28,7 @@ export type PluginMap = Record<string, boolean>;
 export type Config = {
   plugins?: PluginMap;
   rules?: RuleMap;
-  settings?: Record<string, any>;
+  settings?: Settings;
 };
 
 export const configSchema: ZodType<Config> = z.object({

--- a/packages/validation/src/utils/fingerprint.ts
+++ b/packages/validation/src/utils/fingerprint.ts
@@ -1,0 +1,50 @@
+import {FingerPrints, ValidationResult} from '../common/sarif';
+
+const DEFAULT_SEED = 1337;
+
+export function fingerprint(result: ValidationResult): FingerPrints {
+  const v1 = monokleHashV1(result);
+  return {
+    'monokleHash/v1': v1,
+  };
+}
+
+/**
+ * The hash algorithm used to provide a stable identifier to a validation result.
+ *
+ * @see https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc10541092
+ */
+function monokleHashV1(result: ValidationResult): string {
+  const tool = result.rule.toolComponent.name;
+  const rule = result.rule.id;
+  const resource = result.locations[1].logicalLocations?.find(l => l.kind === 'resource')?.fullyQualifiedName;
+  const yamlPath = result.locations[1].logicalLocations?.find(l => l.kind === 'element')?.name;
+
+  const stableIdentifier = `${tool}#${rule}#${resource}#${yamlPath}`;
+  return fastHash(stableIdentifier);
+}
+
+/**
+ * Hash the content of a string to a short, convenient identifier.
+ *
+ * The hash is sync and fast but inconsistent with git.
+ * The hash is generated with cyrb53 which is like MurmurHash but faster and simpler at the cost of less random.
+ * @see https://stackoverflow.com/a/52171480
+ * @example hash("a") === "501c2ba782c97901"
+ */
+export function fastHash(input: string, seed = DEFAULT_SEED): string {
+  let h1 = 0xdeadbeef ^ seed;
+  let h2 = 0x41c6ce57 ^ seed;
+
+  for (let i = 0, ch; i < input.length; i++) {
+    ch = input.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+  const h = 4294967296 * (2097151 & h2) + (h1 >>> 0);
+  return h.toString(16);
+}

--- a/packages/validation/src/validators/custom/simpleValidator.ts
+++ b/packages/validation/src/validators/custom/simpleValidator.ts
@@ -112,7 +112,7 @@ export class SimpleCustomValidator extends AbstractPlugin {
     const node = determineClosestNodeForPath(parsedDoc, path);
     const region = node?.range ? this._parser.parseErrorRegion(resource, node.range) : undefined;
 
-    const locations = createLocations(resource, region);
+    const locations = createLocations(resource, region, path);
 
     return this.createValidationResult(rule.id, {
       message: {
@@ -192,11 +192,11 @@ function toSarifRules(plugin: PluginInit): RuleMetadata[] {
       properties: {
         'security-severity': r.advanced?.severity,
         configMetadata: r.advanced?.configMetadata
-        ? {
-          type: r.advanced.configMetadata.type,
-          name: r.advanced.configMetadata.name,
-        }
-      : undefined,
+          ? {
+              type: r.advanced.configMetadata.type,
+              name: r.advanced.configMetadata.name,
+            }
+          : undefined,
       },
       relationships: r.advanced?.relationships,
     };

--- a/packages/validation/src/validators/open-policy-agent/validator.ts
+++ b/packages/validation/src/validators/open-policy-agent/validator.ts
@@ -8,7 +8,7 @@ import {z} from 'zod';
 import {AbstractPlugin} from '../../common/AbstractPlugin.js';
 import {ResourceParser} from '../../common/resourceParser.js';
 import {Region, ValidationResult, RuleMetadata} from '../../common/sarif.js';
-import {Incremental, Resource} from '../../common/types.js';
+import {Incremental, Resource, YamlPath} from '../../common/types.js';
 import {createLocations} from '../../utils/createLocations.js';
 import {isDefined} from '../../utils/isDefined.js';
 import {OPEN_POLICY_AGENT_RULES} from './rules.js';
@@ -25,8 +25,6 @@ const Settings = z.object({
 });
 
 const CONTROLLER_KINDS = ['Deployment', 'StatefulSet', 'Job', 'DaemonSet', 'ReplicaSet', 'ReplicationController'];
-
-type YamlPath = Array<string | number>;
 
 export class OpenPolicyAgentValidator extends AbstractPlugin {
   static toolName = 'open-policy-agent';


### PR DESCRIPTION
This PR introduced fingerprints; you can also optionally provide a baseline validation response (e.g. the previous one or when you started your "workspace session") to see which results are new, unchanged or absent.

This could be leveraged within with the VSC Extension as baseline is prominently present there.