### PR TITLE
chore: remove react-fast-compare

### DIFF
--- a/.changeset/silent-cars-glow.md
+++ b/.changeset/silent-cars-glow.md
@@ -1,0 +1,5 @@
+---
+"@monokle/validation": patch
+---
+
+remove react-fast-compare to fix build

--- a/package-lock.json
+++ b/package-lock.json
@@ -27239,7 +27239,7 @@
     },
     "packages/components": {
       "name": "@monokle/components",
-      "version": "1.5.5",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "react-fast-compare": "^3.2.1"
@@ -27247,7 +27247,7 @@
       "devDependencies": {
         "@ant-design/icons": "4.7.0",
         "@babel/core": "7.17.8",
-        "@monokle/validation": "0.20.1",
+        "@monokle/validation": "0.25.0",
         "@rjsf/antd": "5.0.0-beta.11",
         "@storybook/addon-actions": "6.5.16",
         "@storybook/addon-essentials": "6.5.16",
@@ -27288,12 +27288,12 @@
         "allotment": "^1.19.0",
         "antd": "^4.0.0",
         "elkjs": "^0.8.2",
-        "framer-motion": "^6.0 || ^7.0",
+        "framer-motion": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
         "html-to-image": "^1.11.11",
         "jspdf": "^2.5.1",
         "react": "^18.0 || ^17.0 || ^16.0",
         "react-dom": "^18.0 || ^17.0 || ^16.0",
-        "styled-components": "^5.0.0",
+        "styled-components": "^5.0.0 || ^6.0.0",
         "use-debounced-effect": "2.0.1"
       }
     },
@@ -27331,10 +27331,10 @@
       "license": "MIT"
     },
     "packages/monaco-kubernetes": {
-      "version": "0.2.7",
+      "version": "0.2.12",
       "license": "MIT",
       "dependencies": {
-        "@monokle/validation": "^0.20.0",
+        "@monokle/validation": "^0.25.0",
         "@types/json-schema": "^7.0.0",
         "jsonc-parser": "^3.0.0",
         "monaco-marker-data-provider": "^1.0.0",
@@ -27951,7 +27951,7 @@
     },
     "packages/validation": {
       "name": "@monokle/validation",
-      "version": "0.20.1",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@open-policy-agent/opa-wasm": "1.8.0",
@@ -27961,7 +27961,6 @@
         "isomorphic-fetch": "3.0.0",
         "lodash": "4.17.21",
         "node-fetch": "3.3.0",
-        "react-fast-compare": "3.2.1",
         "require-from-string": "2.0.2",
         "rollup": "3.18.0",
         "yaml": "2.2.2",
@@ -30827,7 +30826,7 @@
       "requires": {
         "@ant-design/icons": "4.7.0",
         "@babel/core": "7.17.8",
-        "@monokle/validation": "0.20.1",
+        "@monokle/validation": "0.25.0",
         "@rjsf/antd": "5.0.0-beta.11",
         "@storybook/addon-actions": "6.5.16",
         "@storybook/addon-essentials": "6.5.16",
@@ -31220,7 +31219,6 @@
         "isomorphic-fetch": "3.0.0",
         "lodash": "4.17.21",
         "node-fetch": "3.3.0",
-        "react-fast-compare": "3.2.1",
         "require-from-string": "2.0.2",
         "rimraf": "3.0.2",
         "rollup": "3.18.0",
@@ -42267,7 +42265,7 @@
     "monaco-kubernetes": {
       "version": "file:packages/monaco-kubernetes",
       "requires": {
-        "@monokle/validation": "^0.20.0",
+        "@monokle/validation": "^0.25.0",
         "@types/json-schema": "^7.0.0",
         "@types/uuid": "9.0.0",
         "esbuild": "^0.15.0",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -67,7 +67,6 @@
     "isomorphic-fetch": "3.0.0",
     "lodash": "4.17.21",
     "node-fetch": "3.3.0",
-    "react-fast-compare": "3.2.1",
     "require-from-string": "2.0.2",
     "rollup": "3.18.0",
     "yaml": "2.2.2",

--- a/packages/validation/src/MonokleValidator.ts
+++ b/packages/validation/src/MonokleValidator.ts
@@ -1,7 +1,7 @@
 import clone from 'lodash/clone.js';
 import difference from 'lodash/difference.js';
 import uniqueId from 'lodash/uniqueId.js';
-import isEqual from 'react-fast-compare';
+import isEqual from 'lodash/isEqual.js';
 import {ResourceParser} from './common/resourceParser.js';
 import type {Tool, ValidationResponse, ValidationResult, ValidationRun} from './common/sarif.js';
 import type {CustomSchema, Incremental, Plugin, Resource} from './common/types.js';

--- a/packages/validation/src/references/utils/getResourceNodes.ts
+++ b/packages/validation/src/references/utils/getResourceNodes.ts
@@ -2,7 +2,7 @@ import {Document, isPair, isScalar, isSeq, Scalar, visit} from 'yaml';
 import {getRefMappers} from './getRefMappers.js';
 import {RefNode, Resource, ResourceRefsProcessingConfig} from '../../common/types.js';
 import {REF_PATH_SEPARATOR, NAME_REFNODE_PATH} from '../../constants.js';
-import isEqual from 'react-fast-compare';
+import isEqual from 'lodash/isEqual.js';
 
 const resourceRefNodesCache = new Map<string, Record<string, RefNode[] | undefined>>();
 


### PR DESCRIPTION
This PR removes react-fast-compare as it gives runtime errors due to some build tooling.

As to performance implications, there are non, all isEqual comparisons are on sets with less than 5 elements in it so this was premature optimisation