### PR TITLE
feat(validation): make validation ESM/CJS package [WIP]

### DIFF
--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -4,24 +4,25 @@
   "description": "Kubernetes resource validation",
   "author": "Kubeshop",
   "license": "MIT",
-  "type": "module",
   "sideEffects": false,
-  "main": "lib/index.js",
-  "source": "src/index.ts",
-  "module": "lib/index.js",
-  "types": "lib/index.d.ts",
-  "typings": "lib/index.d.ts",
+  "main": "lib/cjs/index.js",
+  "module": "lib/mjs/index.js",
   "exports": {
     ".": {
-      "node": "./lib/node.js",
-      "module": "./lib/index.js",
-      "default": "./lib/index.js"
+      "node": "./lib/mjs/node.js",
+      "module": "./lib/mjs/index.js",
+      "default": "./lib/mjs/index.js",
+      "import": "./lib/mjs/index.js",
+      "require": "./lib/cjs/index.js"
     },
     "./custom": {
-      "types": "./lib/custom.d.ts",
-      "module": "./lib/custom.js"
+      "types": "./lib/mjs/custom.d.ts",
+      "module": "./lib/mjs/custom.js"
     }
   },
+  "source": "src/index.ts",
+  "types": "lib/mjs/index.d.ts",
+  "typings": "lib/mjs/index.d.ts",
   "files": [
     "lib/**"
   ],
@@ -29,7 +30,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --segfault-retry=3",
     "test:snapshot": "vitest --update",
-    "build": "rimraf lib && tsc --build tsconfig.build.json",
+    "build": "rimraf lib && tsc --build tsconfig.build.mjs.json && tsc --build tsconfig.build.cjs.json && node ./scripts/fixup.js",
     "format:all": "prettier --write \"{src,test}/**/*.{js,jsx,ts,tsx}\""
   },
   "repository": {

--- a/packages/validation/scripts/fixup.js
+++ b/packages/validation/scripts/fixup.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const path = require('path');
+
+const packageMjs = path.join(__dirname, '../lib/mjs/package.json');
+fs.writeFileSync(packageMjs, JSON.stringify({type: "module"}, null, 2));
+
+const packageCjs = path.join(__dirname, '../lib/cjs/package.json');
+fs.writeFileSync(packageCjs, JSON.stringify({type: "commonjs"}, null, 2));

--- a/packages/validation/tsconfig.build.cjs.json
+++ b/packages/validation/tsconfig.build.cjs.json
@@ -7,5 +7,10 @@
     "src/__tests__/**",
     "**/*.test.ts"
   ],
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "lib/cjs",
+    "target": "ES2015"
+  }
 }

--- a/packages/validation/tsconfig.build.mjs.json
+++ b/packages/validation/tsconfig.build.mjs.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "lib",
+    "src/utils/testing/**",
+    "src/__tests__/**",
+    "**/*.test.ts"
+  ],
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "lib/mjs",
+  }
+}

--- a/packages/validation/tsconfig.json
+++ b/packages/validation/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib",
     "lib": ["ESNext", "DOM"],
     "module": "ESNext",
     "target": "ESNext",


### PR DESCRIPTION
This PR makes validation package a hybrid ESM/CJS one.

It started with VSCode extension not really supporting ESM-only packages. Such can be only imported with dynamic import which has a number of limitations AFAIU, see https://github.com/kubeshop/vscode-monokle/issues/8. And then it seems VSC team does not have any timeline or clear incentive to support such - you can read the discussion here https://github.com/microsoft/vscode/issues/130367.

It was [okeyish for validation import](https://github.com/kubeshop/vscode-monokle/blob/1f4674cb05cbda08737e14a59991ebddd3061f56/src/utils/validation.ts#L212-L214) only, but the same issue happens with new `synchronizer` package. And since `synchronizer` depends on `validation` package (well, for types import only but still) both needs to be CJS.

Based on https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html.

**This is WIP** as I still need to test if it works wit VSC and Cloud correctly without breaking anything, I'm still not sure if other dependencies won't cause issues too.

## Changes

- Reworked how package is build to expose both ESM and CJS versions.

## Fixes

- None.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
