### PR TITLE
feat(synchronizer): update device flow default configuration

### DIFF
--- a/.changeset/gentle-jokes-invent.md
+++ b/.changeset/gentle-jokes-invent.md
@@ -1,0 +1,5 @@
+---
+"@monokle/synchronizer": minor
+---
+
+Changed default device flow handler configuration to prod env

--- a/packages/synchronizer/src/__tests__/authenticator.spec.ts
+++ b/packages/synchronizer/src/__tests__/authenticator.spec.ts
@@ -266,10 +266,12 @@ async function race(successPromise: Promise<void>, errorMsg: string) {
     successPromise.then(() => {
       isSuccess = true;
     }),
-    new Promise(() => setTimeout(() => {
-      if (!isSuccess){
-        assert.fail(errorMsg);
-      }
-    }, 250)),
+    new Promise(() =>
+      setTimeout(() => {
+        if (!isSuccess) {
+          assert.fail(errorMsg);
+        }
+      }, 250)
+    ),
   ]);
 }

--- a/packages/synchronizer/src/__tests__/synchronizer.spec.ts
+++ b/packages/synchronizer/src/__tests__/synchronizer.spec.ts
@@ -292,7 +292,7 @@ describe('Synchronizer Tests', () => {
             resolve(policy);
           });
         }),
-        'Synchronize event not triggered',
+        'Synchronize event not triggered'
       );
 
       await synchronizer.getPolicy(repoData, true, 'SAMPLE_ACCESS_TOKEN');
@@ -330,10 +330,12 @@ async function race(successPromise: Promise<void>, errorMsg: string) {
     successPromise.then(() => {
       isSuccess = true;
     }),
-    new Promise(() => setTimeout(() => {
-      if (!isSuccess){
-        assert.fail(errorMsg);
-      }
-    }, 250)),
+    new Promise(() =>
+      setTimeout(() => {
+        if (!isSuccess) {
+          assert.fail(errorMsg);
+        }
+      }, 250)
+    ),
   ]);
 }

--- a/packages/synchronizer/src/constants.ts
+++ b/packages/synchronizer/src/constants.ts
@@ -3,7 +3,7 @@ export const DEFAULT_STORAGE_CONFIG_FILE_AUTH = 'auth.yaml';
 
 export const DEFAULT_API_URL = 'https://api.monokle.com';
 
-export const DEFAULT_DEVICE_FLOW_IDP_URL = 'https://id.dev.monokle.com/realms/monokle';
+export const DEFAULT_DEVICE_FLOW_IDP_URL = 'https://id.monokle.com/realms/monokle';
 export const DEFAULT_DEVICE_FLOW_CLIENT_ID = 'mc-cli';
 export const DEFAULT_DEVICE_FLOW_CLIENT_SECRET = '';
 export const DEFAULT_DEVICE_FLOW_ALG = 'ES512';

--- a/packages/synchronizer/src/handlers/deviceFlowHandler.ts
+++ b/packages/synchronizer/src/handlers/deviceFlowHandler.ts
@@ -1,6 +1,17 @@
 import {Issuer} from 'openid-client';
-import {DEFAULT_DEVICE_FLOW_IDP_URL, DEFAULT_DEVICE_FLOW_CLIENT_ID, DEFAULT_DEVICE_FLOW_CLIENT_SECRET, DEFAULT_DEVICE_FLOW_ALG, DEFAULT_DEVICE_FLOW_CLIENT_SCOPE} from '../constants.js';
-import type {BaseClient, ClientMetadata, DeviceFlowHandle as DeviceFlowHandleOpenId, TokenSet as TokenSetOpenId} from 'openid-client';
+import {
+  DEFAULT_DEVICE_FLOW_IDP_URL,
+  DEFAULT_DEVICE_FLOW_CLIENT_ID,
+  DEFAULT_DEVICE_FLOW_CLIENT_SECRET,
+  DEFAULT_DEVICE_FLOW_ALG,
+  DEFAULT_DEVICE_FLOW_CLIENT_SCOPE,
+} from '../constants.js';
+import type {
+  BaseClient,
+  ClientMetadata,
+  DeviceFlowHandle as DeviceFlowHandleOpenId,
+  TokenSet as TokenSetOpenId,
+} from 'openid-client';
 
 export type DeviceFlowHandle = DeviceFlowHandleOpenId<BaseClient>;
 
@@ -16,7 +27,7 @@ export class DeviceFlowHandler {
       client_secret: DEFAULT_DEVICE_FLOW_CLIENT_SECRET,
       id_token_signed_response_alg: DEFAULT_DEVICE_FLOW_ALG,
     },
-    private _clientScope: string = DEFAULT_DEVICE_FLOW_CLIENT_SCOPE,
+    private _clientScope: string = DEFAULT_DEVICE_FLOW_CLIENT_SCOPE
   ) {}
 
   async initializeAuthFlow(): Promise<DeviceFlowHandle> {

--- a/packages/synchronizer/src/utils/synchronizer.ts
+++ b/packages/synchronizer/src/utils/synchronizer.ts
@@ -71,7 +71,7 @@ export class Synchronizer extends EventEmitter {
   }
 
   generateDeepLink(path: string) {
-    return this._apiHandler.generateDeepLink(path)
+    return this._apiHandler.generateDeepLink(path);
   }
 
   private async fetchPolicy(repoData: RepoRemoteData, accessToken: string) {


### PR DESCRIPTION
This PR changes device flow handler default configuration to prod env.

See this commit - https://github.com/kubeshop/monokle-core/pull/484/commits/9f92ffcfc06d3bfaa76b48bfd667ac0c813a3e5b, rest is just code formatting.

## Changes

- As above.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
