### PR TITLE
feat(parser): add flag to filter helm template files

### DIFF
--- a/.changeset/many-jobs-dress.md
+++ b/.changeset/many-jobs-dress.md
@@ -1,0 +1,5 @@
+---
+"@monokle/parser": minor
+---
+
+Added flag to filter helm template files during parsing

--- a/packages/parser/src/extract.ts
+++ b/packages/parser/src/extract.ts
@@ -1,14 +1,18 @@
 import {LineCounter} from 'yaml';
 import {parseAllYamlDocuments} from './parse.js';
 import {Resource, createResourceId, createResourceName} from './resource.js';
-import {BaseFile, isUntypedKustomizationFile} from './file.js';
+import {BaseFile, isUntypedKustomizationFile, isYamlFile, hasHelmTemplateContent} from './file.js';
 import {KUSTOMIZATION_API_GROUP, KUSTOMIZATION_KIND} from './constants.js';
 import {isKubernetesLike} from './k8s.js';
 
-export function extractK8sResources(files: BaseFile[]): Resource[] {
+export function extractK8sResources(files: BaseFile[], extractHelmLikeFiles?: boolean): Resource[] {
   const resources: Resource[] = [];
 
   for (const file of files) {
+    if (!isYamlFile(file) || (!extractHelmLikeFiles && hasHelmTemplateContent(file))) {
+      continue;
+    }
+
     const lineCounter = new LineCounter();
     const documents = parseAllYamlDocuments(file.content, lineCounter);
 

--- a/packages/parser/src/file.ts
+++ b/packages/parser/src/file.ts
@@ -13,3 +13,9 @@ export function isYamlFile(file: BaseFile): boolean {
 export function isUntypedKustomizationFile(filePath = ''): boolean {
   return /kustomization*.yaml/.test(filePath.toLowerCase().trim());
 }
+
+const HELM_TEMPLATE_CONTENT_REGEX = /{{[^}]*}}/;
+
+export function hasHelmTemplateContent(file: BaseFile) {
+  return HELM_TEMPLATE_CONTENT_REGEX.test(file.content || '');
+}


### PR DESCRIPTION
This PR adds Helm template files filtering needed for https://github.com/kubeshop/monokle-cli/issues/24.

## Changes

- Adjusted `extractK8sResources()` method to filter Helm template files by default.

## Fixes

- None.

## Remarks

Initially I used [what Cloud does](https://github.com/kubeshop/monokle-saas/blob/c14f1c6f3bc524aa00a844016e6960f3517d8fa8/clientDomain/web/src/utils/yaml.ts#L13-L28) but recognizing Helm files based on `templates` string in file path or simple `/values.*.(yaml|yml)/` regex seems error prone (in fact one test in `validation` package was already failing due to that). So I went with recognizing Helm template files based on template syntax present in file content - `{{ ... }}`.

Now, it's not 100% perfect because I can imagine one can have a template without any `{{ ... }}` (but then it will be the same as just vanilla K8s manifest, so not sure if makes any sense). It will not filter it out then but also parser will work fine not throwing errors.

The 2nd thing (and this is similar for Cloud, AFAIU), even if we pass `extractHelmLikeFiles=true`, template files will still error during parsing and will be filtered out... If we want to use Helm templates files further, those should have dedicated handling [as  forKustomize files](https://github.com/kubeshop/monokle-core/blob/f6a11d30c4cb9003861d08ef8ab3fc927af72f50/packages/parser/src/extract.ts#L47) (suggest to extract to separate issue).

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
