### PR TITLE
fix(types): remove unallowed semicolon

### DIFF
--- a/.changeset/unlucky-fireants-notice.md
+++ b/.changeset/unlucky-fireants-notice.md
@@ -1,0 +1,5 @@
+---
+"@monokle/types": patch
+---
+
+removed unallowed semicolon from types definitions

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -49,11 +49,11 @@ export interface Suppression {
   kind: SuppressionKind;
   status: SuppressionStatus;
   justification?: string;
-};
+}
 
 export interface ExternalSuppression extends Suppression  {
   guid: string;
-};
+}
 
 export interface AnnotationsSuppression extends Suppression {
   kind: 'inSource';


### PR DESCRIPTION
This PR removes unallowed semicolon from types def file.

It produces "Statements are not allowed in ambient contexts." error. See https://github.com/Microsoft/TypeScript/issues/11987 for more context.

## Changes

- None.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
