### PR TITLE
fix(validation): fix lodash imports

### DIFF
--- a/.changeset/metal-pugs-hide.md
+++ b/.changeset/metal-pugs-hide.md
@@ -1,0 +1,5 @@
+---
+"@monokle/validation": patch
+---
+
+Fixed lodash imports

--- a/packages/validation/src/validators/custom/simpleValidator.ts
+++ b/packages/validation/src/validators/custom/simpleValidator.ts
@@ -1,6 +1,8 @@
 import {paramCase, sentenceCase} from 'change-case';
 import keyBy from 'lodash/keyBy.js';
 import set from 'lodash/set.js';
+import get from 'lodash/get.js';
+import unset from 'lodash/unset.js';
 import {Document, Node, ParsedNode, isNode} from 'yaml';
 import {AbstractPlugin} from '../../common/AbstractPlugin.js';
 import {ResourceParser} from '../../common/resourceParser.js';
@@ -10,7 +12,6 @@ import {Fixer} from '../../sarif/fix/index.js';
 import {createLocations} from '../../utils/createLocations.js';
 import {isDefined} from '../../utils/isDefined.js';
 import {Resource as PlainResource, PluginInit, ReportArgs, RuleInit} from './config.js';
-import {get, unset} from 'lodash';
 
 type Runtime = {
   validate: RuleInit['validate'];


### PR DESCRIPTION
This PR fixes lodash imports. VSC extension CommonJS compatible imports (or something like this, see message below) and so it was breaking:

```
[1] CommonJS modules can always be imported via the default export, for example using:
[1]
[1] import pkg from 'lodash';
[1] const { get, unset } = pkg;
[1] .
[1]   monokle-vsc/node_modules/@monokle/validation/lib/validators/custom/simpleValidator.js:8
[1]   import { get, unset } from 'lodash';
[1]            ^^^
[1]   SyntaxError: Named export 'get' not found. The requested module 'lodash' is a CommonJS module, which may not support all module.exports as named exports.
[1]   CommonJS modules can always be imported via the default export, for example using:
[1]
[1]   import pkg from 'lodash';
[1]   const { get, unset } = pkg;
[1]
[1]     at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
[1]     at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)
```

## Changes

- None.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
