### PR TITLE
Fix token type auth header

### DIFF
--- a/.changeset/tasty-avocados-help.md
+++ b/.changeset/tasty-avocados-help.md
@@ -1,0 +1,5 @@
+---
+"@monokle/synchronizer": minor
+---
+
+Require token object instead of string for API queries

--- a/package-lock.json
+++ b/package-lock.json
@@ -29049,7 +29049,7 @@
     },
     "packages/components": {
       "name": "@monokle/components",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "react-fast-compare": "^3.2.1",
@@ -29058,7 +29058,7 @@
       "devDependencies": {
         "@ant-design/icons": "4.7.0",
         "@babel/core": "7.17.8",
-        "@monokle/validation": "0.28.2",
+        "@monokle/validation": "0.29.1",
         "@rjsf/antd": "5.0.0-beta.11",
         "@storybook/addon-actions": "6.5.16",
         "@storybook/addon-essentials": "6.5.16",
@@ -29144,10 +29144,10 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "packages/monaco-kubernetes": {
-      "version": "0.2.15",
+      "version": "0.2.16",
       "license": "MIT",
       "dependencies": {
-        "@monokle/validation": "^0.28.0",
+        "@monokle/validation": "^0.29.0",
         "@types/json-schema": "^7.0.0",
         "jsonc-parser": "^3.0.0",
         "monaco-marker-data-provider": "^1.0.0",
@@ -29243,7 +29243,7 @@
     },
     "packages/parser": {
       "name": "@monokle/parser",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "4.17.21",
@@ -29826,11 +29826,11 @@
     },
     "packages/types": {
       "name": "@monokle/types",
-      "version": "0.2.1"
+      "version": "0.2.2"
     },
     "packages/validation": {
       "name": "@monokle/validation",
-      "version": "0.28.2",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "@monokle/types": "*",

--- a/packages/synchronizer/src/__tests__/apiHandler.spec.ts
+++ b/packages/synchronizer/src/__tests__/apiHandler.spec.ts
@@ -1,0 +1,46 @@
+import {assert} from 'chai';
+import { ApiHandler } from '../handlers/apiHandler.js';
+
+describe('ApiHandler Tests', () => {
+  describe('Authorization Header', () => {
+    it('formats header correctly (bearer)', async () => {
+      const synchronizer = new ApiHandler();
+      const header = (synchronizer as any).formatAuthorizationHeader({
+      accessToken: 'SAMPLE_TOKEN',
+      tokenType: 'Bearer',
+      });
+
+      assert.equal('Bearer SAMPLE_TOKEN', header);
+    });
+
+    it('formats header correctly (apikey)', async () => {
+      const synchronizer = new ApiHandler();
+      const header = (synchronizer as any).formatAuthorizationHeader({
+      accessToken: 'SAMPLE_TOKEN',
+      tokenType: 'ApiKey',
+      });
+
+      assert.equal('ApiKey SAMPLE_TOKEN', header);
+    });
+
+    it('formats header correctly (invalid)', async () => {
+      const synchronizer = new ApiHandler();
+      const header = (synchronizer as any).formatAuthorizationHeader({
+      accessToken: 'SAMPLE_TOKEN',
+      tokenType: 'invalid',
+      });
+
+      assert.equal('Bearer SAMPLE_TOKEN', header);
+    });
+
+    it('formats header correctly (not set)', async () => {
+      const synchronizer = new ApiHandler();
+      const header = (synchronizer as any).formatAuthorizationHeader({
+      accessToken: 'SAMPLE_TOKEN',
+      tokenType: undefined,
+      });
+
+      assert.equal('Bearer SAMPLE_TOKEN', header);
+    });
+  });
+});

--- a/packages/synchronizer/src/__tests__/apiHandler.spec.ts
+++ b/packages/synchronizer/src/__tests__/apiHandler.spec.ts
@@ -1,13 +1,13 @@
 import {assert} from 'chai';
-import { ApiHandler } from '../handlers/apiHandler.js';
+import {ApiHandler} from '../handlers/apiHandler.js';
 
 describe('ApiHandler Tests', () => {
   describe('Authorization Header', () => {
     it('formats header correctly (bearer)', async () => {
       const synchronizer = new ApiHandler();
       const header = (synchronizer as any).formatAuthorizationHeader({
-      accessToken: 'SAMPLE_TOKEN',
-      tokenType: 'Bearer',
+        accessToken: 'SAMPLE_TOKEN',
+        tokenType: 'Bearer',
       });
 
       assert.equal('Bearer SAMPLE_TOKEN', header);
@@ -16,8 +16,8 @@ describe('ApiHandler Tests', () => {
     it('formats header correctly (apikey)', async () => {
       const synchronizer = new ApiHandler();
       const header = (synchronizer as any).formatAuthorizationHeader({
-      accessToken: 'SAMPLE_TOKEN',
-      tokenType: 'ApiKey',
+        accessToken: 'SAMPLE_TOKEN',
+        tokenType: 'ApiKey',
       });
 
       assert.equal('ApiKey SAMPLE_TOKEN', header);
@@ -26,8 +26,8 @@ describe('ApiHandler Tests', () => {
     it('formats header correctly (invalid)', async () => {
       const synchronizer = new ApiHandler();
       const header = (synchronizer as any).formatAuthorizationHeader({
-      accessToken: 'SAMPLE_TOKEN',
-      tokenType: 'invalid',
+        accessToken: 'SAMPLE_TOKEN',
+        tokenType: 'invalid',
       });
 
       assert.equal('Bearer SAMPLE_TOKEN', header);
@@ -36,8 +36,8 @@ describe('ApiHandler Tests', () => {
     it('formats header correctly (not set)', async () => {
       const synchronizer = new ApiHandler();
       const header = (synchronizer as any).formatAuthorizationHeader({
-      accessToken: 'SAMPLE_TOKEN',
-      tokenType: undefined,
+        accessToken: 'SAMPLE_TOKEN',
+        tokenType: undefined,
       });
 
       assert.equal('Bearer SAMPLE_TOKEN', header);

--- a/packages/synchronizer/src/__tests__/authenticator.spec.ts
+++ b/packages/synchronizer/src/__tests__/authenticator.spec.ts
@@ -1,4 +1,4 @@
-import { parse, stringify } from 'yaml'
+import {parse, stringify} from 'yaml';
 import {dirname, resolve} from 'path';
 import {fileURLToPath} from 'url';
 import {rm, mkdir, cp, readFile, writeFile} from 'fs/promises';

--- a/packages/synchronizer/src/__tests__/authenticator.spec.ts
+++ b/packages/synchronizer/src/__tests__/authenticator.spec.ts
@@ -44,7 +44,7 @@ describe('Authenticator Tests', () => {
       assert.isTrue(user.isAuthenticated);
       assert.equal(user.email, 'user1@kubeshop.io');
       assert.equal(user.token, 'USER1_ACCESS_TOKEN');
-      assert.equal(user.data?.auth?.token.token_type, 'access_token');
+      assert.equal(user.data?.auth?.token.token_type, 'ApiKey');
     });
 
     it('should return user data on init when auth file present (device code method)', async () => {
@@ -138,7 +138,7 @@ describe('Authenticator Tests', () => {
       assert.isTrue(user.isAuthenticated);
       assert.equal(user.email, 'user3@kubeshop.io');
       assert.equal(user.token, 'USER3_ACCESS_TOKEN');
-      assert.equal(user.data?.auth?.token.token_type, 'access_token');
+      assert.equal(user.data?.auth?.token.token_type, 'ApiKey');
     });
 
     it('should login with device code', async () => {
@@ -267,7 +267,7 @@ describe('Authenticator Tests', () => {
       assert.isTrue(userNew.isAuthenticated);
       assert.equal(userNew.email, 'user1@kubeshop.io');
       assert.equal(userNew.token, 'USER1_ACCESS_TOKEN');
-      assert.equal(userNew.data?.auth?.token.token_type, 'access_token');
+      assert.equal(userNew.data?.auth?.token.token_type, 'ApiKey');
 
       assert.equal(deviceFlowRefreshSpy.callCount, 0);
     });

--- a/packages/synchronizer/src/__tests__/fixtures/auth.token.yaml
+++ b/packages/synchronizer/src/__tests__/fixtures/auth.token.yaml
@@ -2,4 +2,4 @@ auth:
   email: user1@kubeshop.io
   token:
     access_token: 'USER1_ACCESS_TOKEN'
-    token_type: access_token
+    token_type: ApiKey

--- a/packages/synchronizer/src/__tests__/synchronizer.spec.ts
+++ b/packages/synchronizer/src/__tests__/synchronizer.spec.ts
@@ -182,7 +182,10 @@ describe('Synchronizer Tests', () => {
 
       assert.isFalse(policy.valid);
 
-      const newPolicy = await synchronizer.getPolicy(repoData, true, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'Bearer'});
+      const newPolicy = await synchronizer.getPolicy(repoData, true, {
+        accessToken: 'SAMPLE_ACCESS_TOKEN',
+        tokenType: 'Bearer',
+      });
 
       assert.isObject(newPolicy);
       assert.isTrue(newPolicy.valid);
@@ -248,7 +251,10 @@ describe('Synchronizer Tests', () => {
 
       assert.isFalse(policy.valid);
 
-      const newPolicy = await synchronizer.getPolicy(policyData, true, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'ApiKey'});
+      const newPolicy = await synchronizer.getPolicy(policyData, true, {
+        accessToken: 'SAMPLE_ACCESS_TOKEN',
+        tokenType: 'ApiKey',
+      });
 
       assert.isObject(newPolicy);
       assert.isTrue(newPolicy.valid);
@@ -417,7 +423,10 @@ describe('Synchronizer Tests', () => {
         name: 'monokle-core',
       };
 
-      const projectInfo = await synchronizer.getProjectInfo(repoData, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'ApiKey'});
+      const projectInfo = await synchronizer.getProjectInfo(repoData, {
+        accessToken: 'SAMPLE_ACCESS_TOKEN',
+        tokenType: 'ApiKey',
+      });
 
       assert.isObject(projectInfo);
       assert.equal(projectInfo!.id, 6000);
@@ -454,7 +463,10 @@ describe('Synchronizer Tests', () => {
         slug: 'user7-proj-foobar',
       };
 
-      const projectInfo = await synchronizer.getProjectInfo(projectData, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'Bearer'});
+      const projectInfo = await synchronizer.getProjectInfo(projectData, {
+        accessToken: 'SAMPLE_ACCESS_TOKEN',
+        tokenType: 'Bearer',
+      });
 
       assert.isObject(projectInfo);
       assert.equal(projectInfo!.id, 7000);
@@ -512,15 +524,25 @@ describe('Synchronizer Tests', () => {
         name: 'monokle-core',
       };
 
-      const projectInfo = await synchronizer.getProjectInfo(repoData, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'ApiKey'});
+      const projectInfo = await synchronizer.getProjectInfo(repoData, {
+        accessToken: 'SAMPLE_ACCESS_TOKEN',
+        tokenType: 'ApiKey',
+      });
       assert.equal(projectInfo!.id, 6000);
       assert.equal(queryApiStub.callCount, 1);
 
-      const projectInfoRetry = await synchronizer.getProjectInfo(repoData, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'ApiKey'});
+      const projectInfoRetry = await synchronizer.getProjectInfo(repoData, {
+        accessToken: 'SAMPLE_ACCESS_TOKEN',
+        tokenType: 'ApiKey',
+      });
       assert.equal(projectInfoRetry!.id, 6000);
       assert.equal(queryApiStub.callCount, 1);
 
-      const projectInfoRetryForce = await synchronizer.getProjectInfo(repoData, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'ApiKey'}, true);
+      const projectInfoRetryForce = await synchronizer.getProjectInfo(
+        repoData,
+        {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'ApiKey'},
+        true
+      );
       assert.equal(projectInfoRetryForce!.id, 6000);
       assert.equal(queryApiStub.callCount, 2);
     });

--- a/packages/synchronizer/src/__tests__/synchronizer.spec.ts
+++ b/packages/synchronizer/src/__tests__/synchronizer.spec.ts
@@ -182,7 +182,7 @@ describe('Synchronizer Tests', () => {
 
       assert.isFalse(policy.valid);
 
-      const newPolicy = await synchronizer.getPolicy(repoData, true, 'SAMPLE_ACCESS_TOKEN');
+      const newPolicy = await synchronizer.getPolicy(repoData, true, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'Bearer'});
 
       assert.isObject(newPolicy);
       assert.isTrue(newPolicy.valid);
@@ -248,7 +248,7 @@ describe('Synchronizer Tests', () => {
 
       assert.isFalse(policy.valid);
 
-      const newPolicy = await synchronizer.getPolicy(policyData, true, 'SAMPLE_ACCESS_TOKEN');
+      const newPolicy = await synchronizer.getPolicy(policyData, true, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'ApiKey'});
 
       assert.isObject(newPolicy);
       assert.isTrue(newPolicy.valid);
@@ -361,7 +361,7 @@ describe('Synchronizer Tests', () => {
         'Synchronize event not triggered'
       );
 
-      await synchronizer.getPolicy(repoData, true, 'SAMPLE_ACCESS_TOKEN');
+      await synchronizer.getPolicy(repoData, true, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'Bearer'});
 
       return result;
     });
@@ -417,7 +417,7 @@ describe('Synchronizer Tests', () => {
         name: 'monokle-core',
       };
 
-      const projectInfo = await synchronizer.getProjectInfo(repoData, 'SAMPLE_ACCESS_TOKEN');
+      const projectInfo = await synchronizer.getProjectInfo(repoData, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'ApiKey'});
 
       assert.isObject(projectInfo);
       assert.equal(projectInfo!.id, 6000);
@@ -454,7 +454,7 @@ describe('Synchronizer Tests', () => {
         slug: 'user7-proj-foobar',
       };
 
-      const projectInfo = await synchronizer.getProjectInfo(projectData, 'SAMPLE_ACCESS_TOKEN');
+      const projectInfo = await synchronizer.getProjectInfo(projectData, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'Bearer'});
 
       assert.isObject(projectInfo);
       assert.equal(projectInfo!.id, 7000);
@@ -512,19 +512,19 @@ describe('Synchronizer Tests', () => {
         name: 'monokle-core',
       };
 
-      const projectInfo = await synchronizer.getProjectInfo(repoData, 'SAMPLE_ACCESS_TOKEN');
+      const projectInfo = await synchronizer.getProjectInfo(repoData, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'ApiKey'});
       assert.equal(projectInfo!.id, 6000);
       assert.equal(queryApiStub.callCount, 1);
 
-      const projectInfoRetry = await synchronizer.getProjectInfo(repoData, 'SAMPLE_ACCESS_TOKEN');
+      const projectInfoRetry = await synchronizer.getProjectInfo(repoData, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'ApiKey'});
       assert.equal(projectInfoRetry!.id, 6000);
       assert.equal(queryApiStub.callCount, 1);
 
-      const projectInfoRetryForce = await synchronizer.getProjectInfo(repoData, 'SAMPLE_ACCESS_TOKEN', true);
+      const projectInfoRetryForce = await synchronizer.getProjectInfo(repoData, {accessToken: 'SAMPLE_ACCESS_TOKEN', tokenType: 'ApiKey'}, true);
       assert.equal(projectInfoRetryForce!.id, 6000);
       assert.equal(queryApiStub.callCount, 2);
     });
-  })
+  });
 });
 
 async function createTmpConfigDir(copyPolicyFixture = '') {

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -215,7 +215,10 @@ export class ApiHandler {
   }
 
   private formatAuthorizationHeader(tokenInfo: TokenInfo) {
-    const tokenType = tokenInfo?.tokenType?.toLowerCase() === 'bearer' || tokenInfo?.tokenType?.toLowerCase() === 'apikey' ? tokenInfo.tokenType : 'Bearer';
-    return `${tokenType} ${tokenInfo.accessToken}`
+    const tokenType =
+      tokenInfo?.tokenType?.toLowerCase() === 'bearer' || tokenInfo?.tokenType?.toLowerCase() === 'apikey'
+        ? tokenInfo.tokenType
+        : 'Bearer';
+    return `${tokenType} ${tokenInfo.accessToken}`;
   }
 }

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -2,6 +2,7 @@ import normalizeUrl from 'normalize-url';
 import fetch from 'node-fetch';
 import {SuppressionStatus} from '@monokle/types';
 import {DEFAULT_API_URL} from '../constants.js';
+import type {TokenInfo} from './storageHandlerAuth.js';
 
 const getUserQuery = `
   query getUser {
@@ -161,20 +162,20 @@ export class ApiHandler {
     return normalizeUrl(this._apiUrl);
   }
 
-  async getUser(accessToken: string): Promise<ApiUserData | undefined> {
-    return this.queryApi(getUserQuery, accessToken);
+  async getUser(tokenInfo: TokenInfo): Promise<ApiUserData | undefined> {
+    return this.queryApi(getUserQuery, tokenInfo);
   }
 
-  async getProject(slug: string, accessToken: string): Promise<ApiProjectData | undefined> {
-    return this.queryApi(getProjectQuery, accessToken, {slug});
+  async getProject(slug: string, tokenInfo: TokenInfo): Promise<ApiProjectData | undefined> {
+    return this.queryApi(getProjectQuery, tokenInfo, {slug});
   }
 
-  async getPolicy(slug: string, accessToken: string): Promise<ApiPolicyData | undefined> {
-    return this.queryApi(getPolicyQuery, accessToken, {slug});
+  async getPolicy(slug: string, tokenInfo: TokenInfo): Promise<ApiPolicyData | undefined> {
+    return this.queryApi(getPolicyQuery, tokenInfo, {slug});
   }
 
-  async getSuppressions(repositoryId: string, accessToken: string): Promise<ApiSuppressionsData | undefined> {
-    return this.queryApi(getSuppressionsQuery, accessToken, {repositoryId});
+  async getSuppressions(repositoryId: string, tokenInfo: TokenInfo): Promise<ApiSuppressionsData | undefined> {
+    return this.queryApi(getSuppressionsQuery, tokenInfo, {repositoryId});
   }
 
   generateDeepLink(path: string) {
@@ -189,14 +190,14 @@ export class ApiHandler {
     return normalizeUrl(`${this.apiUrl}/${path}`);
   }
 
-  private async queryApi<OUT>(query: string, token: string, variables = {}): Promise<OUT | undefined> {
+  private async queryApi<OUT>(query: string, tokenInfo: TokenInfo, variables = {}): Promise<OUT | undefined> {
     const apiEndpointUrl = normalizeUrl(`${this.apiUrl}/graphql`);
 
     const response = await fetch(apiEndpointUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
+        Authorization: this.formatAuthorizationHeader(tokenInfo),
       },
       body: JSON.stringify({
         query,
@@ -211,5 +212,10 @@ export class ApiHandler {
     }
 
     return response.json() as Promise<OUT>;
+  }
+
+  private formatAuthorizationHeader(tokenInfo: TokenInfo) {
+    const tokenType = tokenInfo?.tokenType?.toLowerCase() === 'bearer' || tokenInfo?.tokenType?.toLowerCase() === 'apikey' ? tokenInfo.tokenType : 'Bearer';
+    return `${tokenType} ${tokenInfo.accessToken}`
   }
 }

--- a/packages/synchronizer/src/handlers/storageHandler.ts
+++ b/packages/synchronizer/src/handlers/storageHandler.ts
@@ -67,7 +67,7 @@ export abstract class StorageHandler<TData> {
       await mkdirp(dir);
       await writeFile(file, data);
     } catch (err: any) {
-      throw new Error(`Failed to write configuration to '${file}' with error: ${err.message} and data: ${data}`,);
+      throw new Error(`Failed to write configuration to '${file}' with error: ${err.message} and data: ${data}`);
     }
   }
 }

--- a/packages/synchronizer/src/handlers/storageHandlerAuth.ts
+++ b/packages/synchronizer/src/handlers/storageHandlerAuth.ts
@@ -3,9 +3,16 @@ import {StorageHandler} from './storageHandler.js';
 import {DEFAULT_STORAGE_CONFIG_FILE_AUTH, DEFAULT_STORAGE_CONFIG_FOLDER} from '../constants.js';
 import type {TokenSet} from './deviceFlowHandler.js';
 
+export type TokenType = 'Bearer' | 'ApiKey';
+
+export type TokenInfo = {
+  accessToken: string;
+  tokenType: TokenType;
+};
+
 export type AccessToken = {
   access_token: string;
-  token_type: 'access_token';
+  token_type: 'ApiKey';
 };
 
 export type Token = AccessToken | TokenSet;

--- a/packages/synchronizer/src/models/user.ts
+++ b/packages/synchronizer/src/models/user.ts
@@ -1,8 +1,9 @@
-import type {StorageAuthFormat} from '../handlers/storageHandlerAuth.js';
+import type {StorageAuthFormat, TokenType, TokenInfo} from '../handlers/storageHandlerAuth.js';
 
 export class User {
   private _email: string | null = null;
   private _token: string | null = null;
+  private _tokenInfo: TokenInfo | null = null;
   private _data: StorageAuthFormat | null = null;
   private _isAuthenticated: boolean = false;
 
@@ -12,6 +13,7 @@ export class User {
     if (this._isAuthenticated) {
       this._email = data!.auth!.email;
       this._token = data!.auth!.token.access_token!;
+      this._tokenInfo = { accessToken: this._token, tokenType: data!.auth!.token.token_type! as TokenType };
       this._data = data;
     }
   }
@@ -26,6 +28,10 @@ export class User {
 
   get token() {
     return this._token;
+  }
+
+  get tokenInfo() {
+    return this._tokenInfo;
   }
 
   get data() {

--- a/packages/synchronizer/src/models/user.ts
+++ b/packages/synchronizer/src/models/user.ts
@@ -13,7 +13,7 @@ export class User {
     if (this._isAuthenticated) {
       this._email = data!.auth!.email;
       this._token = data!.auth!.token.access_token!;
-      this._tokenInfo = { accessToken: this._token, tokenType: data!.auth!.token.token_type! as TokenType };
+      this._tokenInfo = {accessToken: this._token, tokenType: data!.auth!.token.token_type! as TokenType};
       this._data = data;
     }
   }

--- a/packages/synchronizer/src/utils/authenticator.ts
+++ b/packages/synchronizer/src/utils/authenticator.ts
@@ -3,7 +3,7 @@ import {User} from '../models/user.js';
 import {StorageHandlerAuth} from '../handlers/storageHandlerAuth.js';
 import {ApiHandler} from '../handlers/apiHandler.js';
 import {DeviceFlowHandler} from '../handlers/deviceFlowHandler.js';
-import type {Token} from '../handlers/storageHandlerAuth.js';
+import type {Token, TokenType} from '../handlers/storageHandlerAuth.js';
 import type {DeviceFlowHandle, TokenSet} from '../handlers/deviceFlowHandler.js';
 
 export type AuthMethod = 'device code' | 'token';
@@ -80,7 +80,7 @@ export class Authenticator extends EventEmitter {
       return;
     }
 
-    if (tokenData.token_type === 'access_token') {
+    if (tokenData.token_type === 'ApiKey') {
       return;
     }
 
@@ -112,7 +112,7 @@ export class Authenticator extends EventEmitter {
   private async loginWithToken(token: string): Promise<AuthenticatorLoginResponse> {
     const tokenData: Token = {
       access_token: token,
-      token_type: 'access_token',
+      token_type: 'ApiKey',
     };
 
     const donePromise: Promise<User> = new Promise((resolve, reject) => {
@@ -164,7 +164,10 @@ export class Authenticator extends EventEmitter {
   }
 
   private async setUserData(token: Token) {
-    const userApiData = await this._apiHandler.getUser(token.access_token!);
+    const userApiData = await this._apiHandler.getUser({
+      accessToken: token.access_token!,
+      tokenType: token.token_type! as TokenType,
+    });
 
     await this._storageHandler.setStoreData({
       auth: {


### PR DESCRIPTION
This PR aligns auth header with required schema. Needed for https://github.com/kubeshop/monokle-cli/issues/25.

## Changes

- None.

## Fixes

- Reworked API query related methods to use token object (with token and token type) instead of token string only.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
