### PR TITLE
fix(synchronizer): add more explicit GraphQL API error handling

### DIFF
--- a/.changeset/famous-knives-mix.md
+++ b/.changeset/famous-knives-mix.md
@@ -1,0 +1,5 @@
+---
+"@monokle/synchronizer": patch
+---
+
+Added more explicit GraphQL API error handling


### PR DESCRIPTION
This PR adds more explicit GraphQL API error handling. Needed for https://github.com/kubeshop/monokle-cli/issues/25.

Due the the way it was done before, almost all errors thrown by API handler in `synchronize` resulted in _The ... project does not have policy defined. Configure it on ..._ error message which was quite confusing, when for example invalid token was used.

I added more explicit handling of such errors in ApiHandler.

## Changes

- None.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
