### PR TITLE
feat: add ValidatingAdmissionPolicy references

### DIFF
--- a/.changeset/pretty-donkeys-wash.md
+++ b/.changeset/pretty-donkeys-wash.md
@@ -1,0 +1,5 @@
+---
+"@monokle/validation": minor
+---
+
+Add ValidatingAdmissionPolicy references

--- a/packages/validation/src/references/mappers/mappers.ts
+++ b/packages/validation/src/references/mappers/mappers.ts
@@ -12,6 +12,7 @@ import {endpointSliceMappers} from './endpointSlice.js';
 import {Resource} from '../../common/types.js';
 import {isDefined} from '../../utils/isDefined.js';
 import {ownerReferenceMapper} from './ownerReference.js';
+import {validatingAdmissionPolicyBindingMappers} from './validatingAdmissionPolicyBinding';
 
 export type SiblingMatcher = (
   source: Resource,
@@ -82,6 +83,7 @@ export const OUTGOING_MAPPERS_BY_KIND: Partial<Record<KnownResourceKinds, RefMap
   PersistentVolume: persistentVolumeMapper,
   RoleBinding: roleBindingMappers,
   ClusterRoleBinding: clusterRoleBindingMappers,
+  ValidatingAdmissionPolicyBinding: validatingAdmissionPolicyBindingMappers,
   VolumeAttachment: volumeAttachmentMappers,
   Endpoints: endpointsMappers,
   EndpointSlice: endpointSliceMappers,

--- a/packages/validation/src/references/mappers/validatingAdmissionPolicyBinding.ts
+++ b/packages/validation/src/references/mappers/validatingAdmissionPolicyBinding.ts
@@ -1,0 +1,13 @@
+import {RefMapper} from './mappers.js';
+
+export const validatingAdmissionPolicyBindingMappers: RefMapper[] = [
+  {
+    type: 'name',
+    source: {
+      pathParts: ['policyName'],
+    },
+    target: {
+      kind: 'ValidatingAdmissionPolicy',
+    },
+  },
+];

--- a/packages/validation/src/references/process.ts
+++ b/packages/validation/src/references/process.ts
@@ -1,7 +1,7 @@
 import groupBy from 'lodash/groupBy.js';
 import keyBy from 'lodash/keyBy.js';
 import uniq from 'lodash/uniq.js';
-import {Incremental, Resource, ResourceRefsProcessingConfig} from '../common/types.js';
+import {Incremental, Resource, ResourceRefsProcessingConfig, ResourceRefType, YamlPath} from '../common/types.js';
 import {handlePairRefMapping} from './handlePairRefMapping.js';
 import {handleRefMappingByKey} from './handleRefMappingByKey.js';
 import {getOutgoingRefMappers} from './mappers/index.js';
@@ -12,6 +12,8 @@ import {getResourceRefNodes} from './utils/getResourceNodes.js';
 import {refMapperMatchesKind} from './utils/refMatcher.js';
 import {processKustomizations} from './utils/kustomizeRefs.js';
 import {ResourceParser} from '../common/resourceParser.js';
+import {isDefined} from '../utils/isDefined';
+import {isNode} from 'yaml';
 
 /**
  * Processes resources and MUTATES them with their references to other resources.
@@ -84,7 +86,122 @@ function doProcessRefs(resources: Resource[], resourcesToProcess: Resource[], co
         handleRefMappingByKey(sourceResource, targetResources, outgoingRefMapper, config);
       }
     }
+
+    if (sourceResource.kind === 'ValidatingAdmissionPolicyBinding') {
+      processValidatingAdmissionPolicyParams(sourceResource, resourceMap, resourcesByKind, config.parser);
+    }
   }
 
   cleanResourceRefs(resources);
+}
+
+/**
+ * Process references to parameters of ValidationAdmissionPolicyBindings.
+ *
+ * These are quite unique as it needs a referenced Policy object to determine the referenced Params object.
+ * To avoid further complicating the reference framework, we handle this as a one-off special case.
+ */
+function processValidatingAdmissionPolicyParams(
+  policyBinding: Resource,
+  resourceMap: Record<string, Resource>,
+  resourcesByKind: Record<string, Resource[]>,
+  parser: ResourceParser
+) {
+  const paramName = policyBinding.content?.spec?.paramRef?.name;
+  const {paramKind} = determineParamKind(policyBinding, resourceMap);
+  const paramNamespace = policyBinding.content?.spec?.paramRef?.namespace;
+
+  if (!policyBinding.refs || !paramName || !paramKind) {
+    return;
+  }
+
+  const relatedParams = resourcesByKind[paramKind].find(o => {
+    const matchingName = paramName === o.name;
+    const matchingNamespace = paramNamespace ? paramNamespace === o.namespace : true;
+    return matchingName && matchingNamespace;
+  });
+
+  if (!relatedParams) {
+    return;
+  }
+
+  // Add reference to Binding object
+  policyBinding.refs.push({
+    type: ResourceRefType.Outgoing,
+    name: paramName,
+    target: {
+      type: 'resource',
+      resourceId: relatedParams.id,
+      resourceKind: relatedParams.kind,
+    },
+    position: getPosition(parser, policyBinding, ['spec', 'paramRef', 'name']),
+  });
+
+  // Add reference to Params object
+  if (!relatedParams.refs) {
+    relatedParams.refs = [];
+  }
+
+  const hasRef = relatedParams.refs.some(
+    ref =>
+      ref.type === ResourceRefType.Incoming &&
+      ref.name === paramName &&
+      ref.target &&
+      ref.target.type === 'resource' &&
+      ref.target.resourceId === policyBinding.id
+  );
+  if (hasRef) {
+    return;
+  }
+
+  relatedParams.refs.push({
+    type: ResourceRefType.Incoming,
+    name: paramName,
+    target: {
+      type: 'resource',
+      resourceId: policyBinding.id,
+      resourceKind: policyBinding.kind,
+    },
+    position: getPosition(parser, relatedParams, ['metadata', 'name']),
+  });
+}
+
+function determineParamKind(
+  policyBinding: Resource,
+  resourceMap: Record<string, Resource>
+): {paramKind: string | undefined; paramApiVersion: string | undefined} {
+  if (!policyBinding.refs) {
+    return {paramKind: undefined, paramApiVersion: undefined};
+  }
+
+  const relatedPolicy = policyBinding.refs
+    .map(ref => (ref.target?.type === 'resource' ? ref.target.resourceId : undefined))
+    .filter(isDefined)
+    .map(relatedId => resourceMap[relatedId])
+    .find(object => object?.kind === 'ValidatingAdmissionPolicy');
+
+  return {
+    paramKind: relatedPolicy?.content?.spec?.paramKind?.kind,
+    paramApiVersion: relatedPolicy?.content?.spec?.paramKind?.apiVersion,
+  };
+}
+
+function getPosition(parser: ResourceParser, object: Resource, path: YamlPath) {
+  const parsedObject = parser.parse(object);
+  const node = parsedObject.parsedDoc.getIn(path, true);
+
+  if (!isNode(node)) {
+    return {line: 0, column: 0, length: 0};
+  }
+
+  if (node && parsedObject.lineCounter && node.range) {
+    const linePos = parsedObject.lineCounter.linePos(node.range[0]);
+    return {
+      line: linePos.line,
+      column: linePos.col,
+      length: node.range[1] - node.range[0],
+    };
+  }
+
+  return {line: 0, column: 0, length: 0};
 }

--- a/packages/validation/src/utils/knownResourceKinds.ts
+++ b/packages/validation/src/utils/knownResourceKinds.ts
@@ -33,4 +33,6 @@ export const KNOWN_RESOURCE_KINDS = [
   'StatefulSet',
   'StorageClass',
   'VolumeAttachment',
+  'ValidatingAdmissionPolicy',
+  'ValidatingAdmissionPolicyBinding',
 ] as const;


### PR DESCRIPTION
This PR adds references for Binding.policyName -> Policy.metadata.name and Binding.paramsRef.name -> ParamsKind.metadata.name.

The params do not use the standard framework as it requires referencing the Policy to find the referenced Params which is a special case. Expanding the framework for this special edge case would complicate it too much so I kept it on the side.