### PR TITLE
Add util for direct API querying

### DIFF
--- a/.changeset/clever-years-fix.md
+++ b/.changeset/clever-years-fix.md
@@ -1,0 +1,5 @@
+---
+"@monokle/synchronizer": minor
+---
+
+Introduced util for direct API querying

--- a/package-lock.json
+++ b/package-lock.json
@@ -29244,7 +29244,7 @@
     },
     "packages/components": {
       "name": "@monokle/components",
-      "version": "2.3.3",
+      "version": "2.3.4",
       "license": "MIT",
       "dependencies": {
         "react-fast-compare": "^3.2.1",

--- a/packages/synchronizer/src/__tests__/fetcher.spec.ts
+++ b/packages/synchronizer/src/__tests__/fetcher.spec.ts
@@ -1,0 +1,115 @@
+import sinon from 'sinon';
+import {assert} from 'chai';
+import {createDefaultMonokleFetcher} from '../createDefaultMonokleFetcher.js';
+
+const TEST_QUERY = `
+  query getCluster($id: ID) {
+    getCluster(id: ID) {
+      cluster {
+        id
+        name
+        namespaceSync
+
+        namespaces {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+type TEST_QUERY_RESULT_TYPE = {
+  getCluster: {
+    cluster: {
+      id: string;
+      name: string;
+      namespaceSync: boolean;
+      namespaces: {
+        id: string;
+        name: string;
+      }[];
+    };
+  };
+}
+
+describe('Fetcher Tests', () => {
+  const stubs: sinon.SinonStub[] = [];
+
+  afterEach(async () => {
+    if (stubs.length) {
+      stubs.forEach(stub => stub.restore());
+    }
+  });
+
+  describe('query', () => {
+    it('runs a query with a valid token', async () => {
+      const fetcher = createDefaultMonokleFetcher();
+
+      fetcher.useAutomationToken('SAMPLE_TOKEN');
+
+      const sendRequestStub = sinon
+        .stub((fetcher as any)._apiHandler, 'sendRequest')
+        .callsFake(async (...args) => {
+          return {
+            ok: true,
+            json: async () => {
+              return {
+                errors: [],
+                data: {
+                  getCluster: {
+                    cluster: {
+                      id: 'cluster-1',
+                      name: 'Cluster 1',
+                      namespaceSync: true,
+                      namespaces: [{
+                        id: 'ns1',
+                        name: 'NS 1'
+                      }, {
+                        id: 'ns2',
+                        name: 'NS 2'
+                      }]
+                    }
+                  }
+                },
+              };
+            },
+          };
+        });
+      stubs.push(sendRequestStub);
+
+      const queryResult = await fetcher.query<TEST_QUERY_RESULT_TYPE>(TEST_QUERY);
+
+      assert.isTrue(queryResult.success);
+      assert.isUndefined(queryResult.error);
+      assert.isDefined(queryResult.data);
+      assert.equal(queryResult.data?.getCluster?.cluster?.id, 'cluster-1');
+    });
+
+    it('returns error when no token set', async () => {
+      const fetcher = createDefaultMonokleFetcher();
+      const queryResult = await fetcher.query<TEST_QUERY_RESULT_TYPE>(TEST_QUERY);
+
+      assert.isFalse(queryResult.success);
+      assert.isUndefined(queryResult.data);
+      assert.match(queryResult.error ?? '', /No token set/);
+    });
+
+    it('return error when API query fails', async () => {
+      const fetcher = createDefaultMonokleFetcher();
+
+      fetcher.useAutomationToken('SAMPLE_TOKEN');
+
+      const sendRequestStub = sinon
+        .stub((fetcher as any)._apiHandler, 'sendRequest')
+        .throws(new Error('Connection error. Cannot fetch data from https://api.monokle.com/graphql. Error \'Not Found\' (404).'));
+      stubs.push(sendRequestStub);
+
+      const queryResult = await fetcher.query<TEST_QUERY_RESULT_TYPE>(TEST_QUERY);
+
+      assert.isFalse(queryResult.success);
+      assert.isUndefined(queryResult.data);
+      assert.match(queryResult.error ?? '', /Connection error/);
+    });
+  });
+});

--- a/packages/synchronizer/src/__tests__/fetcher.spec.ts
+++ b/packages/synchronizer/src/__tests__/fetcher.spec.ts
@@ -31,7 +31,7 @@ type TEST_QUERY_RESULT_TYPE = {
       }[];
     };
   };
-}
+};
 
 describe('Fetcher Tests', () => {
   const stubs: sinon.SinonStub[] = [];
@@ -48,34 +48,35 @@ describe('Fetcher Tests', () => {
 
       fetcher.useAutomationToken('SAMPLE_TOKEN');
 
-      const sendRequestStub = sinon
-        .stub((fetcher as any)._apiHandler, 'sendRequest')
-        .callsFake(async (...args) => {
-          return {
-            ok: true,
-            json: async () => {
-              return {
-                errors: [],
-                data: {
-                  getCluster: {
-                    cluster: {
-                      id: 'cluster-1',
-                      name: 'Cluster 1',
-                      namespaceSync: true,
-                      namespaces: [{
+      const sendRequestStub = sinon.stub((fetcher as any)._apiHandler, 'sendRequest').callsFake(async (...args) => {
+        return {
+          ok: true,
+          json: async () => {
+            return {
+              errors: [],
+              data: {
+                getCluster: {
+                  cluster: {
+                    id: 'cluster-1',
+                    name: 'Cluster 1',
+                    namespaceSync: true,
+                    namespaces: [
+                      {
                         id: 'ns1',
-                        name: 'NS 1'
-                      }, {
+                        name: 'NS 1',
+                      },
+                      {
                         id: 'ns2',
-                        name: 'NS 2'
-                      }]
-                    }
-                  }
+                        name: 'NS 2',
+                      },
+                    ],
+                  },
                 },
-              };
-            },
-          };
-        });
+              },
+            };
+          },
+        };
+      });
       stubs.push(sendRequestStub);
 
       const queryResult = await fetcher.query<TEST_QUERY_RESULT_TYPE>(TEST_QUERY);
@@ -102,7 +103,11 @@ describe('Fetcher Tests', () => {
 
       const sendRequestStub = sinon
         .stub((fetcher as any)._apiHandler, 'sendRequest')
-        .throws(new Error('Connection error. Cannot fetch data from https://api.monokle.com/graphql. Error \'Not Found\' (404).'));
+        .throws(
+          new Error(
+            "Connection error. Cannot fetch data from https://api.monokle.com/graphql. Error 'Not Found' (404)."
+          )
+        );
       stubs.push(sendRequestStub);
 
       const queryResult = await fetcher.query<TEST_QUERY_RESULT_TYPE>(TEST_QUERY);

--- a/packages/synchronizer/src/createDefaultMonokleFetcher.ts
+++ b/packages/synchronizer/src/createDefaultMonokleFetcher.ts
@@ -1,0 +1,8 @@
+import {ApiHandler} from './handlers/apiHandler.js';
+import {Fetcher} from './utils/fetcher.js';
+
+export function createDefaultMonokleFetcher(
+  apiHandler: ApiHandler = new ApiHandler()
+) {
+  return new Fetcher(apiHandler);
+}

--- a/packages/synchronizer/src/createDefaultMonokleFetcher.ts
+++ b/packages/synchronizer/src/createDefaultMonokleFetcher.ts
@@ -1,8 +1,6 @@
 import {ApiHandler} from './handlers/apiHandler.js';
 import {Fetcher} from './utils/fetcher.js';
 
-export function createDefaultMonokleFetcher(
-  apiHandler: ApiHandler = new ApiHandler()
-) {
+export function createDefaultMonokleFetcher(apiHandler: ApiHandler = new ApiHandler()) {
   return new Fetcher(apiHandler);
 }

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -190,7 +190,7 @@ export class ApiHandler {
     return normalizeUrl(`${this.apiUrl}/${path}`);
   }
 
-  private async queryApi<OUT>(query: string, tokenInfo: TokenInfo, variables = {}): Promise<OUT | undefined> {
+  async queryApi<OUT>(query: string, tokenInfo: TokenInfo, variables = {}): Promise<OUT | undefined> {
     const apiEndpointUrl = normalizeUrl(`${this.apiUrl}/graphql`);
     const response = await this.sendRequest(apiEndpointUrl, tokenInfo, query, variables);
 

--- a/packages/synchronizer/src/utils/fetcher.ts
+++ b/packages/synchronizer/src/utils/fetcher.ts
@@ -1,0 +1,66 @@
+import {EventEmitter} from 'events';
+import {ApiHandler} from '../handlers/apiHandler.js';
+import {TokenInfo} from '../handlers/storageHandlerAuth.js';
+
+export type ApiResponse<T_DATA> = {
+  errors: any[];
+  data: T_DATA | undefined;
+};
+
+export type QueryResult<T_DATA> = {
+  data: T_DATA | undefined;
+  success: boolean;
+  error?: string;
+};
+
+export class Fetcher extends EventEmitter {
+  private _token: TokenInfo | undefined;
+
+  constructor(
+    private _apiHandler: ApiHandler,
+  ) {
+    super();
+  }
+
+  useBearerToken(token: string) {
+    this._token = {
+      accessToken: token,
+      tokenType: 'Bearer',
+    };
+  }
+
+  useAutomationToken(token: string) {
+    this._token = {
+      accessToken: token,
+      tokenType: 'ApiKey',
+    };
+  }
+
+  async query<T_DATA>(query: string, variables?: any): Promise<QueryResult<T_DATA>> {
+    if (!this._token) {
+      return {
+        data: undefined,
+        success: false,
+        error: 'No token set. Use useBearerToken or useAutomationToken before calling query.',
+      }
+    }
+
+    this.emit('queryStarted', {apiUrl: this._apiHandler.apiUrl, query, variables});
+
+    const result: QueryResult<T_DATA> = {
+      data: undefined,
+      success: false,
+    }
+
+    try {
+      const response = await this._apiHandler.queryApi<ApiResponse<T_DATA>>(query, this._token, variables);
+      result.data = response?.data;
+      result.success = true;
+    } catch (error: any) {
+      result.error = error.message;
+    } finally {
+      this.emit(result.success ? 'queryDone' : 'queryFailed', {apiUrl: this._apiHandler.apiUrl, query, variables, result});
+      return result;
+    }
+  }
+}

--- a/packages/synchronizer/src/utils/fetcher.ts
+++ b/packages/synchronizer/src/utils/fetcher.ts
@@ -16,9 +16,7 @@ export type QueryResult<T_DATA> = {
 export class Fetcher extends EventEmitter {
   private _token: TokenInfo | undefined;
 
-  constructor(
-    private _apiHandler: ApiHandler,
-  ) {
+  constructor(private _apiHandler: ApiHandler) {
     super();
   }
 
@@ -42,7 +40,7 @@ export class Fetcher extends EventEmitter {
         data: undefined,
         success: false,
         error: 'No token set. Use useBearerToken or useAutomationToken before calling query.',
-      }
+      };
     }
 
     this.emit('queryStarted', {apiUrl: this._apiHandler.apiUrl, query, variables});
@@ -50,7 +48,7 @@ export class Fetcher extends EventEmitter {
     const result: QueryResult<T_DATA> = {
       data: undefined,
       success: false,
-    }
+    };
 
     try {
       const response = await this._apiHandler.queryApi<ApiResponse<T_DATA>>(query, this._token, variables);
@@ -59,7 +57,12 @@ export class Fetcher extends EventEmitter {
     } catch (error: any) {
       result.error = error.message;
     } finally {
-      this.emit(result.success ? 'queryDone' : 'queryFailed', {apiUrl: this._apiHandler.apiUrl, query, variables, result});
+      this.emit(result.success ? 'queryDone' : 'queryFailed', {
+        apiUrl: this._apiHandler.apiUrl,
+        query,
+        variables,
+        result,
+      });
       return result;
     }
   }


### PR DESCRIPTION
This PR introduces simple util for querying API directly.

This is needed in admission controller. Since some queries will be run only there I decided not to add dedicated methods for each query, just expose generic query method.

Also, it could be as simple as exposing `ApiHandler.queryApi()` (done [here](https://github.com/kubeshop/monokle-core/compare/f1ames/feat/synchronizer-query-api?expand=1#diff-ae165efda7978099364452ee8aae12dc7c6546a4d09712a4601880dd4a853593R193)) but then it would require additional error handling, passing token object, etc. Also `ApiHandler` is designed to be an internal one and exposing it would encourage direct usage. So `Fetcher` (btw. we can work on the name) util wraps it nicely and allows to just run `fetcherInstance.query(graphQlQuery)`.

## Changes

- As above.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
