### PR TITLE
Add missing synchronizer/fetcher export

### DIFF
--- a/.changeset/warm-radios-hang.md
+++ b/.changeset/warm-radios-hang.md
@@ -1,0 +1,5 @@
+---
+"@monokle/synchronizer": patch
+---
+
+Add missing fetcher export

--- a/packages/synchronizer/src/index.ts
+++ b/packages/synchronizer/src/index.ts
@@ -13,4 +13,5 @@ export * from './utils/synchronizer.js';
 export * from './constants.js';
 
 export * from './createDefaultMonokleAuthenticator.js';
+export * from './createDefaultMonokleFetcher.js';
 export * from './createDefaultMonokleSynchronizer.js';


### PR DESCRIPTION
This PR adds missing synchronizer/fetcher export. Somehow missed it in #554.

## Changes

- None.

## Fixes

- As described.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
