### PR TITLE
Allow synchronization with explicit project slug

### DIFF
--- a/.changeset/tiny-lizards-perform.md
+++ b/.changeset/tiny-lizards-perform.md
@@ -1,0 +1,5 @@
+---
+"@monokle/synchronizer": minor
+---
+
+Allow synchronization with explicit project slug

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -85,6 +85,16 @@ const getSuppressionsQuery = `
   }
 `;
 
+const getRepoIdQuery = `
+  query getRepoId($projectSlug: String!, $repoName: String!, $repoOwner: String!) {
+    getProject(input: { slug: $projectSlug }) {
+      repository(input: { name: $repoName, owner: $repoOwner }) {
+        id
+      }
+    }
+  }
+`;
+
 export type ApiUserProjectRepo = {
   id: string;
   projectId: number;
@@ -155,6 +165,16 @@ export type ApiSuppressionsData = {
   };
 };
 
+export type ApiRepoIdData = {
+  data: {
+    getProject: {
+      repository: {
+        id: string
+      }
+    }
+  }
+};
+
 export class ApiHandler {
   constructor(private _apiUrl: string = DEFAULT_API_URL) {
     if ((_apiUrl || '').length === 0) {
@@ -180,6 +200,10 @@ export class ApiHandler {
 
   async getSuppressions(repositoryId: string, tokenInfo: TokenInfo): Promise<ApiSuppressionsData | undefined> {
     return this.queryApi(getSuppressionsQuery, tokenInfo, {repositoryId});
+  }
+
+  async getRepoId(projectSlug: string, repoOwner: string, repoName: string, tokenInfo: TokenInfo): Promise<ApiRepoIdData | undefined> {
+    return this.queryApi(getRepoIdQuery, tokenInfo, {projectSlug, repoOwner, repoName});
   }
 
   generateDeepLink(path: string) {

--- a/packages/synchronizer/src/utils/synchronizer.ts
+++ b/packages/synchronizer/src/utils/synchronizer.ts
@@ -77,8 +77,9 @@ export class Synchronizer extends EventEmitter {
       };
     }
 
-    const freshProjectInfo = this.isProjectData(inputData)
-      ? await this.getProject(inputData as ProjectInputData, tokenInfo)
+    const projectSlugFromInput = this.getProjectSlug(rootPathOrRepoDataOrProjectData);
+    const freshProjectInfo = projectSlugFromInput
+      ? await this.getProject({ slug: projectSlugFromInput }, tokenInfo)
       : await this.getMatchingProject(inputData as RepoRemoteInputData, tokenInfo);
 
     return !freshProjectInfo


### PR DESCRIPTION
This PR extends synchronizer synchronization API to allow passing project slug with path / repo data. This is useful for scenarios where integration already has project slug (e.g. it was passed by user/developer). It also reduces API requests and permissions issue (e.g. when using Automation Token, `getUser` query is not allowed and it was used to fetch project slug for repo data).

Needed for https://github.com/kubeshop/monokle-saas/issues/2037.

## Changes

- As above.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
