### PR TITLE
fix(synchronizer): use explicit timeouts for API and auth queries

### DIFF
--- a/.changeset/nervous-badgers-call.md
+++ b/.changeset/nervous-badgers-call.md
@@ -1,0 +1,5 @@
+---
+"@monokle/synchronizer": patch
+---
+
+Add explicit timeouts for API communication

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -287,6 +287,7 @@ export class ApiHandler {
         query,
         variables,
       }),
+      timeout: 30 * 1000,
     });
   }
 

--- a/packages/synchronizer/src/handlers/deviceFlowHandler.ts
+++ b/packages/synchronizer/src/handlers/deviceFlowHandler.ts
@@ -1,4 +1,4 @@
-import {Issuer} from 'openid-client';
+import {Issuer, custom} from 'openid-client';
 import {
   DEFAULT_DEVICE_FLOW_IDP_URL,
   DEFAULT_DEVICE_FLOW_CLIENT_ID,
@@ -28,7 +28,11 @@ export class DeviceFlowHandler {
       id_token_signed_response_alg: DEFAULT_DEVICE_FLOW_ALG,
     },
     private _clientScope: string = DEFAULT_DEVICE_FLOW_CLIENT_SCOPE
-  ) {}
+  ) {
+    custom.setHttpOptionsDefaults({
+      timeout: 10 * 1000,
+    });
+  }
 
   async initializeAuthFlow(): Promise<DeviceFlowHandle> {
     const client = await this.getClient();


### PR DESCRIPTION
This PR introduces explicit timeouts for API communication.

For auth it was 3500ms before which is quite short, now 10000ms. For fetch there was no explicit limit (still OS limit applies), now 30000ms.

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
