### PR TITLE
fix(synchronizer): allow to clear user data on origin conflict

### DIFF
--- a/.changeset/three-crews-applaud.md
+++ b/.changeset/three-crews-applaud.md
@@ -1,0 +1,5 @@
+---
+"@monokle/synchronizer": patch
+---
+
+Clear auth user data on origin conflict by default


### PR DESCRIPTION
This PR provides a workaround for origin conflicts.

As described in https://github.com/kubeshop/monokle-saas/issues/2231:

> Origin conflict between integration - when CLI logged in to enterprise, VSC ext will try to use those auth credentials (e.g. refresh token) for default origin (if not yet changed).
>
> This is cumbersome in cases where I first login in with CLI and then start VSC (with Monokle ext) or when I will set origin in one workspace and then switch VSC to another project with different origin. Invalid token error occurs during extension initialization and it won't simply start which is quite an issue.

Since `refreshToken()` method is used on initialization this is enough for now to workaround this issue.

Reported a follow-up for proper handling of this https://github.com/kubeshop/monokle-core/issues/574.

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
