### PR TITLE
chore: add 'schemasOrigin' as predefined 'OriginConfig' key

### DIFF
--- a/.changeset/selfish-adults-beam.md
+++ b/.changeset/selfish-adults-beam.md
@@ -1,0 +1,5 @@
+---
+"@monokle/synchronizer": patch
+---
+
+Added 'schemasOrigin' as predefined 'OriginConfig' key

--- a/packages/synchronizer/src/__tests__/apiHandler.spec.ts
+++ b/packages/synchronizer/src/__tests__/apiHandler.spec.ts
@@ -70,6 +70,7 @@ describe('ApiHandler Tests', () => {
         origin: 'https://test.monokle.com',
         apiOrigin: 'https://api.test.monokle.com',
         authOrigin: 'https://auth.test.monokle.com',
+        schemasOrigin: 'https://schemas.test.monokle.com',
       });
       assert.equal('https://api.test.monokle.com', apiHandler.apiUrl);
     });
@@ -79,6 +80,7 @@ describe('ApiHandler Tests', () => {
         origin: 'https://custom.domain.io',
         apiOrigin: 'https://custom.domain.io/api',
         authOrigin: 'https://custom.domain.io/auth',
+        schemasOrigin: 'https://custom.domain.io/schemas',
       });
 
       assert.equal('https://custom.domain.io/api', apiHandler.apiUrl);
@@ -99,6 +101,7 @@ describe('ApiHandler Tests', () => {
         origin: 'https://custom.domain.io',
         apiOrigin: 'https://custom.domain.io/api',
         authOrigin: 'https://custom.domain.io/auth',
+        schemasOrigin: 'https://custom.domain.io/schemas',
       });
       assert.equal('https://custom.domain.io/projects', apiHandler.generateDeepLink('projects'));
     });

--- a/packages/synchronizer/src/__tests__/fetcher.spec.ts
+++ b/packages/synchronizer/src/__tests__/fetcher.spec.ts
@@ -135,6 +135,8 @@ describe('Fetcher Tests', () => {
 
               OIDC_DISCOVERY_URL: "https://id.monokle.local/realms/monokle",
               CLIENT_ID: "clientId",
+
+              SCHEMA_BASE_URL: "https://plugins.monokle.local/schemas",
             };
           `);
         });
@@ -146,6 +148,7 @@ describe('Fetcher Tests', () => {
             assert.equal(originData?.origin, 'http://localhost:13000');
             assert.equal(originData?.apiOrigin, 'https://api.monokle.local');
             assert.equal(originData?.authOrigin, 'https://id.monokle.local/realms/monokle');
+            assert.equal(originData?.schemasOrigin, 'https://plugins.monokle.local/schemas');
 
             res();
           } catch (err) {

--- a/packages/synchronizer/src/handlers/configHandler.ts
+++ b/packages/synchronizer/src/handlers/configHandler.ts
@@ -5,6 +5,7 @@ export type OriginConfig = {
   origin: string;
   apiOrigin: string;
   authOrigin: string;
+  schemasOrigin: string;
   [key: string]: string;
 };
 
@@ -43,6 +44,7 @@ export async function fetchOriginConfig(origin: string) {
       values.origin = normalizeUrl(origin);
       values.apiOrigin = values.API_ORIGIN;
       values.authOrigin = values.OIDC_DISCOVERY_URL;
+      values.schemasOrigin = values.SCHEMA_BASE_URL;
     }
 
     originConfigCache = {


### PR DESCRIPTION
This PR is a part of https://github.com/kubeshop/monokle-saas/issues/2212.

## Changes

- As above.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
