### PR TITLE
Pass client identity config with every API request

### DIFF
--- a/.changeset/cold-cameras-camp.md
+++ b/.changeset/cold-cameras-camp.md
@@ -1,0 +1,5 @@
+---
+"@monokle/synchronizer": minor
+---
+
+Add mechanism to pass client identity config with every API request

--- a/packages/synchronizer/src/createMonokleAuthenticator.ts
+++ b/packages/synchronizer/src/createMonokleAuthenticator.ts
@@ -1,4 +1,4 @@
-import {ApiHandler} from './handlers/apiHandler.js';
+import {ApiHandler, ClientConfig} from './handlers/apiHandler.js';
 import {DeviceFlowHandler} from './handlers/deviceFlowHandler.js';
 import {StorageHandlerAuth} from './handlers/storageHandlerAuth.js';
 import {Authenticator} from './utils/authenticator.js';
@@ -7,13 +7,14 @@ import {OriginConfig, fetchOriginConfig} from './handlers/configHandler.js';
 
 export async function createMonokleAuthenticatorFromOrigin(
   authClientId: string,
+  clientConfig: ClientConfig,
   origin: string = DEFAULT_ORIGIN,
   storageHandler: StorageHandlerAuth = new StorageHandlerAuth()
 ) {
   try {
     const originConfig = await fetchOriginConfig(origin);
 
-    return createMonokleAuthenticatorFromConfig(authClientId, originConfig, storageHandler);
+    return createMonokleAuthenticatorFromConfig(authClientId, clientConfig, originConfig, storageHandler);
   } catch (err: any) {
     throw err;
   }
@@ -21,25 +22,26 @@ export async function createMonokleAuthenticatorFromOrigin(
 
 export function createMonokleAuthenticatorFromConfig(
   authClientId: string,
-  config: OriginConfig,
+  clientConfig: ClientConfig,
+  originConfig: OriginConfig,
   storageHandler: StorageHandlerAuth = new StorageHandlerAuth()
 ) {
   if (!authClientId) {
     throw new Error(`No auth clientId provided.`);
   }
 
-  if (!config?.apiOrigin) {
+  if (!originConfig?.apiOrigin) {
     throw new Error(`No api origin found in origin config from ${origin}.`);
   }
 
-  if (!config?.authOrigin) {
+  if (!originConfig?.authOrigin) {
     throw new Error(`No auth origin found in origin config from ${origin}.`);
   }
 
   return new Authenticator(
     storageHandler,
-    new ApiHandler(config),
-    new DeviceFlowHandler(config.authOrigin, {
+    new ApiHandler(originConfig, clientConfig),
+    new DeviceFlowHandler(originConfig.authOrigin, {
       client_id: authClientId,
       client_secret: DEFAULT_DEVICE_FLOW_CLIENT_SECRET,
       id_token_signed_response_alg: DEFAULT_DEVICE_FLOW_ALG,

--- a/packages/synchronizer/src/createMonokleFetcher.ts
+++ b/packages/synchronizer/src/createMonokleFetcher.ts
@@ -1,22 +1,22 @@
 import {DEFAULT_ORIGIN} from './constants.js';
-import {ApiHandler} from './handlers/apiHandler.js';
+import {ApiHandler, ClientConfig} from './handlers/apiHandler.js';
 import {OriginConfig, fetchOriginConfig} from './handlers/configHandler.js';
 import {Fetcher} from './utils/fetcher.js';
 
-export async function createMonokleFetcherFromOrigin(origin: string = DEFAULT_ORIGIN) {
+export async function createMonokleFetcherFromOrigin(clientConfig: ClientConfig, origin: string = DEFAULT_ORIGIN) {
   try {
     const originConfig = await fetchOriginConfig(origin);
 
-    return createMonokleFetcherFromConfig(originConfig);
+    return createMonokleFetcherFromConfig(clientConfig, originConfig);
   } catch (err: any) {
     throw err;
   }
 }
 
-export function createMonokleFetcherFromConfig(config: OriginConfig) {
-  if (!config?.apiOrigin) {
+export function createMonokleFetcherFromConfig(clientConfig: ClientConfig, originConfig: OriginConfig) {
+  if (!originConfig?.apiOrigin) {
     throw new Error(`No api origin found in origin config from ${origin}.`);
   }
 
-  return new Fetcher(new ApiHandler(config));
+  return new Fetcher(new ApiHandler(originConfig, clientConfig));
 }

--- a/packages/synchronizer/src/createMonokleSynchronizer.ts
+++ b/packages/synchronizer/src/createMonokleSynchronizer.ts
@@ -1,11 +1,12 @@
 import {DEFAULT_ORIGIN} from './constants.js';
-import {ApiHandler} from './handlers/apiHandler.js';
+import {ApiHandler, ClientConfig} from './handlers/apiHandler.js';
 import {OriginConfig, fetchOriginConfig} from './handlers/configHandler.js';
 import {GitHandler} from './handlers/gitHandler.js';
 import {StorageHandlerPolicy} from './handlers/storageHandlerPolicy.js';
 import {Synchronizer} from './utils/synchronizer.js';
 
 export async function createMonokleSynchronizerFromOrigin(
+  clientConfig: ClientConfig,
   origin: string = DEFAULT_ORIGIN,
   storageHandler: StorageHandlerPolicy = new StorageHandlerPolicy(),
   gitHandler: GitHandler = new GitHandler()
@@ -13,20 +14,21 @@ export async function createMonokleSynchronizerFromOrigin(
   try {
     const originConfig = await fetchOriginConfig(origin);
 
-    return createMonokleSynchronizerFromConfig(originConfig, storageHandler, gitHandler);
+    return createMonokleSynchronizerFromConfig(clientConfig, originConfig, storageHandler, gitHandler);
   } catch (err: any) {
     throw err;
   }
 }
 
 export function createMonokleSynchronizerFromConfig(
-  config: OriginConfig,
+  clientConfig: ClientConfig,
+  originConfig: OriginConfig,
   storageHandler: StorageHandlerPolicy = new StorageHandlerPolicy(),
   gitHandler: GitHandler = new GitHandler()
 ) {
-  if (!config?.apiOrigin) {
+  if (!originConfig?.apiOrigin) {
     throw new Error(`No api origin found in origin config from ${origin}.`);
   }
 
-  return new Synchronizer(storageHandler, new ApiHandler(config), gitHandler);
+  return new Synchronizer(storageHandler, new ApiHandler(originConfig, clientConfig), gitHandler);
 }

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -179,6 +179,8 @@ export type ApiRepoIdData = {
 export type ClientConfig = {
   name: string;
   version: string;
+  os?: string;
+  additionalData?: Record<string, string>;
 };
 
 export class ApiHandler {
@@ -210,6 +212,8 @@ export class ApiHandler {
     this._clientConfig = {
       name: clientConfig?.name || 'unknown',
       version: clientConfig?.version || 'unknown',
+      os: clientConfig?.os || '',
+      additionalData: clientConfig?.additionalData || {},
     };
   }
 
@@ -293,7 +297,7 @@ export class ApiHandler {
       headers: {
         'Content-Type': 'application/json',
         Authorization: this.formatAuthorizationHeader(tokenInfo),
-        'User-Agent': `${this._clientConfig.name}; ${this._clientConfig.version}`,
+        'User-Agent': this.formatUserAgentHeader(this._clientConfig),
       },
       body: JSON.stringify({
         query,
@@ -309,5 +313,19 @@ export class ApiHandler {
         ? tokenInfo.tokenType
         : 'Bearer';
     return `${tokenType} ${tokenInfo.accessToken}`;
+  }
+
+  private formatUserAgentHeader(clientConfig: ClientConfig) {
+    const product = `${clientConfig.name}/${clientConfig.version}`;
+
+    const comment = [];
+    if (clientConfig.os) {
+      comment.push(clientConfig.os);
+    }
+    if (clientConfig.additionalData) {
+      comment.push(Object.entries(clientConfig.additionalData).map(([key, value]) => `${key}=${value}`));
+    }
+
+    return `${product}${comment.length > 0 ? ` (${comment.join('; ')})` : ''}`;
   }
 }

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -210,7 +210,7 @@ export class ApiHandler {
     this._clientConfig = {
       name: clientConfig?.name || 'unknown',
       version: clientConfig?.version || 'unknown',
-    }
+    };
   }
 
   get apiUrl() {

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -176,14 +176,20 @@ export type ApiRepoIdData = {
   };
 };
 
+export type ClientConfig = {
+  name: string;
+  version: string;
+};
+
 export class ApiHandler {
   private _apiUrl: string;
+  private _clientConfig: ClientConfig;
   private _originConfig?: OriginConfig;
 
   constructor();
-  constructor(_apiUrl: string);
-  constructor(_originConfig: OriginConfig);
-  constructor(_apiUrlOrOriginConfig: string | OriginConfig = DEFAULT_API_URL) {
+  constructor(_apiUrl: string, clientConfig?: ClientConfig);
+  constructor(_originConfig: OriginConfig, clientConfig?: ClientConfig);
+  constructor(_apiUrlOrOriginConfig: string | OriginConfig = DEFAULT_API_URL, clientConfig?: ClientConfig) {
     if (typeof _apiUrlOrOriginConfig === 'string') {
       this._apiUrl = _apiUrlOrOriginConfig;
     } else if (
@@ -199,6 +205,11 @@ export class ApiHandler {
 
     if ((this._apiUrl || '').length === 0) {
       this._apiUrl = DEFAULT_API_URL;
+    }
+
+    this._clientConfig = {
+      name: clientConfig?.name || 'unknown',
+      version: clientConfig?.version || 'unknown',
     }
   }
 
@@ -282,6 +293,7 @@ export class ApiHandler {
       headers: {
         'Content-Type': 'application/json',
         Authorization: this.formatAuthorizationHeader(tokenInfo),
+        'User-Agent': `${this._clientConfig.name}; ${this._clientConfig.version}`,
       },
       body: JSON.stringify({
         query,

--- a/packages/synchronizer/src/handlers/configHandler.ts
+++ b/packages/synchronizer/src/handlers/configHandler.ts
@@ -27,10 +27,12 @@ export async function fetchOriginConfig(origin: string, timeout = 30 * 1000) {
 
   try {
     const configUrl = normalize(`${origin}/config.js`);
-    const response = await fetch(configUrl, { timeout });
+    const response = await fetch(configUrl, {timeout});
 
     if (!response.ok) {
-      throw new Error(`Failed to fetch config from ${configUrl} with status ${response.status}: ${response.statusText}`);
+      throw new Error(
+        `Failed to fetch config from ${configUrl} with status ${response.status}: ${response.statusText}`
+      );
     }
 
     const responseText = await response.text();

--- a/packages/synchronizer/src/utils/authenticator.ts
+++ b/packages/synchronizer/src/utils/authenticator.ts
@@ -77,7 +77,7 @@ export class Authenticator extends EventEmitter {
     }
   }
 
-  async refreshToken(force = false, options: RefreshTokenOptions = { logoutOnInvalidGrant: true }) {
+  async refreshToken(force = false, options: RefreshTokenOptions = {logoutOnInvalidGrant: true}) {
     const authData = this._user.data?.auth;
     const tokenData = authData?.token;
 
@@ -104,7 +104,10 @@ export class Authenticator extends EventEmitter {
       } catch (err: any) {
         // This is a workaround for origin conflict where user is logged in already with different origin
         // and authenticator is querying different one.
-        if (options?.logoutOnFail || options?.logoutOnInvalidGrant && err.message.toLowerCase().includes('invalid_grant')) {
+        if (
+          options?.logoutOnFail ||
+          (options?.logoutOnInvalidGrant && err.message.toLowerCase().includes('invalid_grant'))
+        ) {
           await this._storageHandler.emptyStoreData();
           this._user = new User(null);
           // Do not emit logout event since we treat this as user not being logged in with desired origin.


### PR DESCRIPTION
This PR allows to pass config identifying tool/integration using library. The config is then send as `User-Agent` header with every API request. Needed for https://github.com/kubeshop/monokle-saas/issues/1904.

This follows standard format for `User-Agent` headers, for reference see:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
- https://stackoverflow.com/a/2601492

In short:

```
<product>/<product_version> <comment>
```

which in our case could be (the simplest version):

```
Monokle CLI/0.8.0
```

Then `comment` is additional data in `()`. Browsers put there OS info or similar usually, so we will have it there too:

```
Monokle CLI/0.8.0 (OS info)
```

This is also important since `ua-parser-js` library is used on the BE which can parse such OS info properly and will send it as separate payload parameter (see [here](https://github.com/kubeshop/monokle-saas/pull/2281/files#diff-750c12264ed36e2237ddffc41e4642b7425817e60c63e58b139f2836d56154a6R50)).

The `comment` part can also contain other arbitrary data, common format is `key=value; key=value; ...` and this allows us to send any additional data we need, e.g.:

```
Monokle CLI/0.8.0 (OS info; machineId=123; foo=bar)
```

## Changes

- As above.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
