### PR TITLE
feat(synchronizer): add synchronizer query to fetch all validation needed data

### DIFF
--- a/.changeset/silly-starfishes-breathe.md
+++ b/.changeset/silly-starfishes-breathe.md
@@ -1,0 +1,5 @@
+---
+"@monokle/synchronizer": minor
+---
+
+introduced ProjectSynchronzier to allow fetching all project data at once

--- a/packages/synchronizer/src/__tests__/projectSynchronizer.spec.ts
+++ b/packages/synchronizer/src/__tests__/projectSynchronizer.spec.ts
@@ -1,0 +1,252 @@
+import {dirname, resolve} from 'path';
+import {fileURLToPath} from 'url';
+import {rm, mkdir, cp} from 'fs/promises';
+import sinon from 'sinon';
+import {assert} from 'chai';
+import {createMonokleProjectSynchronizerFromConfig} from '../createMonokleProjectSynchronizer.js';
+import {StorageHandlerPolicy} from '../handlers/storageHandlerPolicy.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('ProjectSynchronizer Tests', () => {
+  const stubs: sinon.SinonStub[] = [];
+
+  before(async () => {
+    await cleanupTmpConfigDir();
+  });
+
+  afterEach(async () => {
+    if (stubs.length) {
+      stubs.forEach(stub => stub.restore());
+    }
+
+    await cleanupTmpConfigDir();
+  });
+
+  it('returns empty data if not synchronized', async () => {
+    const storagePath = await createTmpConfigDir();
+    const synchronizer = createSynchronizer(storagePath, stubs);
+
+    const info = synchronizer.getProjectInfo(storagePath);
+    assert.isUndefined(info);
+
+    const permissions = synchronizer.getProjectPermissions(storagePath);
+    assert.isUndefined(permissions);
+
+    const policy = synchronizer.getProjectPolicy(storagePath);
+    assert.isObject(policy);
+    assert.isFalse(policy.valid);
+    assert.isEmpty(policy.path);
+    assert.isEmpty(policy.policy);
+
+    const suppressions = synchronizer.getRepositorySuppressions(storagePath);
+    assert.isArray(suppressions);
+    assert.isEmpty(suppressions);
+  });
+
+  it('throws error when no access token provided for fetch', async () => {
+    try {
+      const storagePath = await createTmpConfigDir();
+      const synchronizer = createSynchronizer(storagePath, stubs);
+
+      await synchronizer.synchronize({} as any, storagePath);
+
+      assert.fail('Should have thrown error.');
+    } catch (err: any) {
+      assert.match(err.message, /Cannot fetch data without access token/);
+    }
+  });
+
+  it('returns valid data after synchronization (repo path)', async () => {
+    const storagePath = await createTmpConfigDir();
+    const synchronizer = createSynchronizer(storagePath, stubs);
+
+    const queryApiStub = sinon.stub((synchronizer as any)._apiHandler, 'queryApi').callsFake(async (...args) => {
+      const query = args[0] as string;
+
+      if (query.includes('query getUser')) {
+        return {
+          data: {
+            me: {
+              id: 1,
+              email: 'user1@kubeshop.io',
+              projects: [
+                {
+                  project: {
+                    id: 1000,
+                    slug: 'user1-proj',
+                    name: 'User1 Project',
+                    repositories: [
+                      {
+                        id: 'user1-proj-policy-id',
+                        projectId: 1000,
+                        provider: 'GITHUB',
+                        owner: 'kubeshop',
+                        name: 'monokle-core',
+                        prChecks: false,
+                        canEnablePrChecks: true,
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        };
+      }
+
+      if (query.includes('query getProject')) {
+        return {
+          data: {
+            getProject: {
+              id: 1000,
+              slug: 'user1-proj',
+              name: 'User1 Project',
+              projectRepository: {
+                id: 'repo1',
+                projectId: 1000,
+                provider: 'GITHUB',
+                owner: 'kubeshop',
+                name: 'monokle-demo',
+                suppressions: [{
+                  id: 'supp-1',
+                  fingerprint: '16587e60761329',
+                  description: 'K8S001 - Value at /spec/replicas should be integer',
+                  location: 'blue-cms.deployment@bundles/simple.yaml@c9cf721b174f5-0',
+                  status: 'ACCEPTED',
+                  justification: null,
+                  expiresAt: null,
+                  updatedAt: '2024-02-01T13:32:10.445Z',
+                  createdAt: '2024-02-01T13:32:10.445Z',
+                  isUnderReview: false,
+                  isAccepted: true,
+                  isRejected: false,
+                  isExpired: true,
+                  isDeleted: false,
+                  repositoryId: 'repo1',
+                }]
+              },
+              permissions: {
+                project: {
+                  view: true,
+                  update: true,
+                  delete: true
+                },
+                members: {
+                  view: true,
+                  update: true,
+                  delete: true
+                },
+                repositories: {
+                  read: true,
+                  write: true
+                }
+              },
+              policy: {
+                id: 'policy1',
+                json: {
+                  plugins: {
+                    "pod-security-standards": false,
+                    "yaml-syntax": true,
+                    "resource-links": true,
+                    "kubernetes-schema": false,
+                    "practices": true,
+                    "metadata": false
+                  },
+                  rules: {
+                    "pod-security-standards/host-process": false,
+                    "pod-security-standards/host-namespaces": false,
+                    "pod-security-standards/privileged-containers": false,
+                    "pod-security-standards/capabilities": false,
+                    "pod-security-standards/host-path-volumes": false,
+                  },
+                  "settings": {
+                    "kubernetes-schema": {
+                      "schemaVersion": 'v1.28.0'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+      }
+
+      return {};
+    });
+    stubs.push(queryApiStub);
+
+    await synchronizer.synchronize({
+      accessToken: 'SAMPLE_TOKEN'
+    } as any, storagePath);
+
+    const info = synchronizer.getProjectInfo(storagePath);
+    assert.isNotEmpty(info);
+    assert.equal(info?.name, 'User1 Project')
+
+    const permissions = synchronizer.getProjectPermissions(storagePath);
+    assert.isObject(permissions);
+    assert.isTrue(permissions?.repositories.write);
+
+    const policy = synchronizer.getProjectPolicy(storagePath);
+    assert.isObject(policy);
+    assert.isTrue(policy.valid);
+    assert.isNotEmpty(policy.path);
+    assert.isNotEmpty(policy.policy);
+
+    const suppressions = synchronizer.getRepositorySuppressions(storagePath);
+    assert.isArray(suppressions);
+    assert.equal(suppressions.length, 1);
+  });
+});
+
+async function createTmpConfigDir(copyPolicyFixture = '') {
+  const testDir = resolve(__dirname, './');
+  const testTmpDir = resolve(testDir, './tmp');
+  const fixturesSourceDir = resolve(testDir, '../../../src/__tests__/fixtures');
+
+  await mkdir(testTmpDir, {recursive: true});
+
+  if (copyPolicyFixture) {
+    await cp(resolve(fixturesSourceDir, copyPolicyFixture), resolve(testTmpDir, copyPolicyFixture));
+  }
+
+  return testTmpDir;
+}
+
+async function cleanupTmpConfigDir() {
+  const testDir = resolve(__dirname, './');
+  const testTmpDir = resolve(testDir, './tmp');
+
+  await rm(testTmpDir, {recursive: true, force: true});
+}
+
+function createSynchronizer(storagePath: string, stubs: sinon.SinonStub[]) {
+  const synchronizer = createMonokleProjectSynchronizerFromConfig(
+    {
+      name: 'Tests',
+      version: 'unknown',
+    },
+    {
+      origin: 'https://monokle.com',
+      apiOrigin: 'https://api.monokle.com',
+      authOrigin: 'https://auth.monokle.com',
+      schemasOrigin: 'https://schemas.monokle.com',
+    },
+    new StorageHandlerPolicy(storagePath)
+  );
+
+  const getRootGitDataStub = sinon.stub((synchronizer as any), 'getRootGitData').callsFake(async () => {
+    return {
+      provider: 'GITHUB',
+      remote: 'origin',
+      owner: 'kubeshop',
+      name: 'monokle-core',
+    };
+  });
+
+  stubs.push(getRootGitDataStub);
+
+  return synchronizer;
+}

--- a/packages/synchronizer/src/__tests__/projectSynchronizer.spec.ts
+++ b/packages/synchronizer/src/__tests__/projectSynchronizer.spec.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import {assert} from 'chai';
 import {createMonokleProjectSynchronizerFromConfig} from '../createMonokleProjectSynchronizer.js';
 import {StorageHandlerPolicy} from '../handlers/storageHandlerPolicy.js';
+import {StorageHandlerJsonCache} from '../handlers/storageHandlerJsonCache.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -58,147 +59,153 @@ describe('ProjectSynchronizer Tests', () => {
     }
   });
 
-  it('returns valid data after synchronization (repo path)', async () => {
-    const storagePath = await createTmpConfigDir();
-    const synchronizer = createSynchronizer(storagePath, stubs);
+  // @TODO
+  // it('returns valid data after synchronization (repo path)', async () => {
+  //   const storagePath = await createTmpConfigDir();
+  //   const synchronizer = createSynchronizer(storagePath, stubs);
 
-    const queryApiStub = sinon.stub((synchronizer as any)._apiHandler, 'queryApi').callsFake(async (...args) => {
-      const query = args[0] as string;
+  //   const queryApiStub = sinon.stub((synchronizer as any)._apiHandler, 'queryApi').callsFake(async (...args) => {
+  //     const query = args[0] as string;
 
-      if (query.includes('query getUser')) {
-        return {
-          data: {
-            me: {
-              id: 1,
-              email: 'user1@kubeshop.io',
-              projects: [
-                {
-                  project: {
-                    id: 1000,
-                    slug: 'user1-proj',
-                    name: 'User1 Project',
-                    repositories: [
-                      {
-                        id: 'user1-proj-policy-id',
-                        projectId: 1000,
-                        provider: 'GITHUB',
-                        owner: 'kubeshop',
-                        name: 'monokle-core',
-                        prChecks: false,
-                        canEnablePrChecks: true,
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-        };
-      }
+  //     if (query.includes('query getUser')) {
+  //       return {
+  //         data: {
+  //           me: {
+  //             id: 1,
+  //             email: 'user1@kubeshop.io',
+  //             projects: [
+  //               {
+  //                 project: {
+  //                   id: 1000,
+  //                   slug: 'user1-proj',
+  //                   name: 'User1 Project',
+  //                   repositories: [
+  //                     {
+  //                       id: 'user1-proj-policy-id',
+  //                       projectId: 1000,
+  //                       provider: 'GITHUB',
+  //                       owner: 'kubeshop',
+  //                       name: 'monokle-core',
+  //                       prChecks: false,
+  //                       canEnablePrChecks: true,
+  //                     },
+  //                   ],
+  //                 },
+  //               },
+  //             ],
+  //           },
+  //         },
+  //       };
+  //     }
 
-      if (query.includes('query getProject')) {
-        return {
-          data: {
-            getProject: {
-              id: 1000,
-              slug: 'user1-proj',
-              name: 'User1 Project',
-              projectRepository: {
-                id: 'repo1',
-                projectId: 1000,
-                provider: 'GITHUB',
-                owner: 'kubeshop',
-                name: 'monokle-demo',
-                suppressions: [{
-                  id: 'supp-1',
-                  fingerprint: '16587e60761329',
-                  description: 'K8S001 - Value at /spec/replicas should be integer',
-                  location: 'blue-cms.deployment@bundles/simple.yaml@c9cf721b174f5-0',
-                  status: 'ACCEPTED',
-                  justification: null,
-                  expiresAt: null,
-                  updatedAt: '2024-02-01T13:32:10.445Z',
-                  createdAt: '2024-02-01T13:32:10.445Z',
-                  isUnderReview: false,
-                  isAccepted: true,
-                  isRejected: false,
-                  isExpired: true,
-                  isDeleted: false,
-                  repositoryId: 'repo1',
-                }]
-              },
-              permissions: {
-                project: {
-                  view: true,
-                  update: true,
-                  delete: true
-                },
-                members: {
-                  view: true,
-                  update: true,
-                  delete: true
-                },
-                repositories: {
-                  read: true,
-                  write: true
-                }
-              },
-              policy: {
-                id: 'policy1',
-                json: {
-                  plugins: {
-                    "pod-security-standards": false,
-                    "yaml-syntax": true,
-                    "resource-links": true,
-                    "kubernetes-schema": false,
-                    "practices": true,
-                    "metadata": false
-                  },
-                  rules: {
-                    "pod-security-standards/host-process": false,
-                    "pod-security-standards/host-namespaces": false,
-                    "pod-security-standards/privileged-containers": false,
-                    "pod-security-standards/capabilities": false,
-                    "pod-security-standards/host-path-volumes": false,
-                  },
-                  "settings": {
-                    "kubernetes-schema": {
-                      "schemaVersion": 'v1.28.0'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        };
-      }
+  //     if (query.includes('query getProject')) {
+  //       return {
+  //         data: {
+  //           getProject: {
+  //             id: 1000,
+  //             slug: 'user1-proj',
+  //             name: 'User1 Project',
+  //             projectRepository: {
+  //               id: 'repo1',
+  //               projectId: 1000,
+  //               provider: 'GITHUB',
+  //               owner: 'kubeshop',
+  //               name: 'monokle-demo',
+  //               suppressions: [{
+  //                 id: 'supp-1',
+  //                 fingerprint: '16587e60761329',
+  //                 description: 'K8S001 - Value at /spec/replicas should be integer',
+  //                 location: 'blue-cms.deployment@bundles/simple.yaml@c9cf721b174f5-0',
+  //                 status: 'ACCEPTED',
+  //                 justification: null,
+  //                 expiresAt: null,
+  //                 updatedAt: '2024-02-01T13:32:10.445Z',
+  //                 createdAt: '2024-02-01T13:32:10.445Z',
+  //                 isUnderReview: false,
+  //                 isAccepted: true,
+  //                 isRejected: false,
+  //                 isExpired: true,
+  //                 isDeleted: false,
+  //                 repositoryId: 'repo1',
+  //               }]
+  //             },
+  //             permissions: {
+  //               project: {
+  //                 view: true,
+  //                 update: true,
+  //                 delete: true
+  //               },
+  //               members: {
+  //                 view: true,
+  //                 update: true,
+  //                 delete: true
+  //               },
+  //               repositories: {
+  //                 read: true,
+  //                 write: true
+  //               }
+  //             },
+  //             policy: {
+  //               id: 'policy1',
+  //               json: {
+  //                 plugins: {
+  //                   "pod-security-standards": false,
+  //                   "yaml-syntax": true,
+  //                   "resource-links": true,
+  //                   "kubernetes-schema": false,
+  //                   "practices": true,
+  //                   "metadata": false
+  //                 },
+  //                 rules: {
+  //                   "pod-security-standards/host-process": false,
+  //                   "pod-security-standards/host-namespaces": false,
+  //                   "pod-security-standards/privileged-containers": false,
+  //                   "pod-security-standards/capabilities": false,
+  //                   "pod-security-standards/host-path-volumes": false,
+  //                 },
+  //                 "settings": {
+  //                   "kubernetes-schema": {
+  //                     "schemaVersion": 'v1.28.0'
+  //                   }
+  //                 }
+  //               }
+  //             }
+  //           }
+  //         }
+  //       };
+  //     }
 
-      return {};
-    });
-    stubs.push(queryApiStub);
+  //     return {};
+  //   });
+  //   stubs.push(queryApiStub);
 
-    await synchronizer.synchronize({
-      accessToken: 'SAMPLE_TOKEN'
-    } as any, storagePath);
+  //   await synchronizer.synchronize({
+  //     accessToken: 'SAMPLE_TOKEN'
+  //   } as any, storagePath);
 
-    const info = synchronizer.getProjectInfo(storagePath);
-    assert.isNotEmpty(info);
-    assert.equal(info?.name, 'User1 Project')
+  //   const info = synchronizer.getProjectInfo(storagePath);
+  //   assert.isNotEmpty(info);
+  //   assert.equal(info?.name, 'User1 Project')
 
-    const permissions = synchronizer.getProjectPermissions(storagePath);
-    assert.isObject(permissions);
-    assert.isTrue(permissions?.repositories.write);
+  //   const permissions = synchronizer.getProjectPermissions(storagePath);
+  //   assert.isObject(permissions);
+  //   assert.isTrue(permissions?.repositories.write);
 
-    const policy = synchronizer.getProjectPolicy(storagePath);
-    assert.isObject(policy);
-    assert.isTrue(policy.valid);
-    assert.isNotEmpty(policy.path);
-    assert.isNotEmpty(policy.policy);
+  //   const policy = synchronizer.getProjectPolicy(storagePath);
+  //   assert.isObject(policy);
+  //   assert.isTrue(policy.valid);
+  //   assert.isNotEmpty(policy.path);
+  //   assert.isNotEmpty(policy.policy);
 
-    const suppressions = synchronizer.getRepositorySuppressions(storagePath);
-    assert.isArray(suppressions);
-    assert.equal(suppressions.length, 1);
-  });
+  //   const suppressions = synchronizer.getRepositorySuppressions(storagePath);
+  //   assert.isArray(suppressions);
+  //   assert.equal(suppressions.length, 1);
+  // });
+
+  // @TODO
+  // it refetches data when timestamps changes
+  // does not refetch data when timestamp same
+  // correctly merges and stores new suppressions
 });
 
 async function createTmpConfigDir(copyPolicyFixture = '') {
@@ -234,7 +241,8 @@ function createSynchronizer(storagePath: string, stubs: sinon.SinonStub[]) {
       authOrigin: 'https://auth.monokle.com',
       schemasOrigin: 'https://schemas.monokle.com',
     },
-    new StorageHandlerPolicy(storagePath)
+    new StorageHandlerPolicy(storagePath),
+    new StorageHandlerJsonCache(storagePath),
   );
 
   const getRootGitDataStub = sinon.stub((synchronizer as any), 'getRootGitData').callsFake(async () => {
@@ -242,7 +250,7 @@ function createSynchronizer(storagePath: string, stubs: sinon.SinonStub[]) {
       provider: 'GITHUB',
       remote: 'origin',
       owner: 'kubeshop',
-      name: 'monokle-core',
+      name: 'monokle-demo',
     };
   });
 

--- a/packages/synchronizer/src/__tests__/projectSynchronizer.spec.ts
+++ b/packages/synchronizer/src/__tests__/projectSynchronizer.spec.ts
@@ -1,7 +1,7 @@
 import {dirname, resolve} from 'path';
 import {fileURLToPath} from 'url';
 import {rm, mkdir, cp} from 'fs/promises';
-import sinon from 'sinon';
+import sinon, { SinonStub } from 'sinon';
 import {assert} from 'chai';
 import {createMonokleProjectSynchronizerFromConfig} from '../createMonokleProjectSynchronizer.js';
 import {StorageHandlerPolicy} from '../handlers/storageHandlerPolicy.js';
@@ -59,153 +59,122 @@ describe('ProjectSynchronizer Tests', () => {
     }
   });
 
-  // @TODO
-  // it('returns valid data after synchronization (repo path)', async () => {
-  //   const storagePath = await createTmpConfigDir();
-  //   const synchronizer = createSynchronizer(storagePath, stubs);
+  it('refetches whole data when force synchronization used', async () => {
+    const storagePath = await createTmpConfigDir();
+    const synchronizer = createSynchronizer(storagePath, stubs);
 
-  //   const queryApiStub = sinon.stub((synchronizer as any)._apiHandler, 'queryApi').callsFake(async (...args) => {
-  //     const query = args[0] as string;
+    const callsCounter = stubApi(synchronizer, stubs);
 
-  //     if (query.includes('query getUser')) {
-  //       return {
-  //         data: {
-  //           me: {
-  //             id: 1,
-  //             email: 'user1@kubeshop.io',
-  //             projects: [
-  //               {
-  //                 project: {
-  //                   id: 1000,
-  //                   slug: 'user1-proj',
-  //                   name: 'User1 Project',
-  //                   repositories: [
-  //                     {
-  //                       id: 'user1-proj-policy-id',
-  //                       projectId: 1000,
-  //                       provider: 'GITHUB',
-  //                       owner: 'kubeshop',
-  //                       name: 'monokle-core',
-  //                       prChecks: false,
-  //                       canEnablePrChecks: true,
-  //                     },
-  //                   ],
-  //                 },
-  //               },
-  //             ],
-  //           },
-  //         },
-  //       };
-  //     }
+    await synchronizer.synchronize({
+      accessToken: 'SAMPLE_TOKEN'
+    } as any, storagePath);
 
-  //     if (query.includes('query getProject')) {
-  //       return {
-  //         data: {
-  //           getProject: {
-  //             id: 1000,
-  //             slug: 'user1-proj',
-  //             name: 'User1 Project',
-  //             projectRepository: {
-  //               id: 'repo1',
-  //               projectId: 1000,
-  //               provider: 'GITHUB',
-  //               owner: 'kubeshop',
-  //               name: 'monokle-demo',
-  //               suppressions: [{
-  //                 id: 'supp-1',
-  //                 fingerprint: '16587e60761329',
-  //                 description: 'K8S001 - Value at /spec/replicas should be integer',
-  //                 location: 'blue-cms.deployment@bundles/simple.yaml@c9cf721b174f5-0',
-  //                 status: 'ACCEPTED',
-  //                 justification: null,
-  //                 expiresAt: null,
-  //                 updatedAt: '2024-02-01T13:32:10.445Z',
-  //                 createdAt: '2024-02-01T13:32:10.445Z',
-  //                 isUnderReview: false,
-  //                 isAccepted: true,
-  //                 isRejected: false,
-  //                 isExpired: true,
-  //                 isDeleted: false,
-  //                 repositoryId: 'repo1',
-  //               }]
-  //             },
-  //             permissions: {
-  //               project: {
-  //                 view: true,
-  //                 update: true,
-  //                 delete: true
-  //               },
-  //               members: {
-  //                 view: true,
-  //                 update: true,
-  //                 delete: true
-  //               },
-  //               repositories: {
-  //                 read: true,
-  //                 write: true
-  //               }
-  //             },
-  //             policy: {
-  //               id: 'policy1',
-  //               json: {
-  //                 plugins: {
-  //                   "pod-security-standards": false,
-  //                   "yaml-syntax": true,
-  //                   "resource-links": true,
-  //                   "kubernetes-schema": false,
-  //                   "practices": true,
-  //                   "metadata": false
-  //                 },
-  //                 rules: {
-  //                   "pod-security-standards/host-process": false,
-  //                   "pod-security-standards/host-namespaces": false,
-  //                   "pod-security-standards/privileged-containers": false,
-  //                   "pod-security-standards/capabilities": false,
-  //                   "pod-security-standards/host-path-volumes": false,
-  //                 },
-  //                 "settings": {
-  //                   "kubernetes-schema": {
-  //                     "schemaVersion": 'v1.28.0'
-  //                   }
-  //                 }
-  //               }
-  //             }
-  //           }
-  //         }
-  //       };
-  //     }
+    assert.equal(callsCounter.getUser, 1);
+    assert.equal(callsCounter.getProject, 1);
+    assert.equal(callsCounter.getPolicy, 1);
+    assert.equal(callsCounter.getSuppression, 1);
 
-  //     return {};
-  //   });
-  //   stubs.push(queryApiStub);
+    await synchronizer.synchronize({
+      accessToken: 'SAMPLE_TOKEN'
+    } as any, storagePath);
 
-  //   await synchronizer.synchronize({
-  //     accessToken: 'SAMPLE_TOKEN'
-  //   } as any, storagePath);
+    assert.equal(callsCounter.getUser, 2);
+    assert.equal(callsCounter.getProject, 2);
+    assert.equal(callsCounter.getPolicy, 1);
+    assert.equal(callsCounter.getSuppression, 2);
 
-  //   const info = synchronizer.getProjectInfo(storagePath);
-  //   assert.isNotEmpty(info);
-  //   assert.equal(info?.name, 'User1 Project')
+    await synchronizer.forceSynchronize({
+      accessToken: 'SAMPLE_TOKEN'
+    } as any, storagePath);
 
-  //   const permissions = synchronizer.getProjectPermissions(storagePath);
-  //   assert.isObject(permissions);
-  //   assert.isTrue(permissions?.repositories.write);
+    assert.equal(callsCounter.getUser, 3);
+    assert.equal(callsCounter.getProject, 3);
+    assert.equal(callsCounter.getPolicy, 2);
+    assert.equal(callsCounter.getSuppression, 3);
+  });
 
-  //   const policy = synchronizer.getProjectPolicy(storagePath);
-  //   assert.isObject(policy);
-  //   assert.isTrue(policy.valid);
-  //   assert.isNotEmpty(policy.path);
-  //   assert.isNotEmpty(policy.policy);
+  it('synchronizes correctly', async () => {
+    const storagePath = await createTmpConfigDir();
+    const synchronizer = createSynchronizer(storagePath, stubs);
 
-  //   const suppressions = synchronizer.getRepositorySuppressions(storagePath);
-  //   assert.isArray(suppressions);
-  //   assert.equal(suppressions.length, 1);
-  // });
+    const callsCounter = stubApi(synchronizer, stubs);
 
-  // @TODO
-  // it refetches data when timestamps changes
-  // does not refetch data when timestamp same
-  // correctly merges and stores new suppressions
+    await synchronizer.synchronize({
+      accessToken: 'SAMPLE_TOKEN'
+    } as any, storagePath);
+
+    const info1 = synchronizer.getProjectInfo(storagePath);
+    assert.isNotEmpty(info1);
+    assert.equal(info1?.name, 'User1 Project')
+
+    const permissions1 = synchronizer.getProjectPermissions(storagePath);
+    assert.isObject(permissions1);
+    assert.isTrue(permissions1?.repositories.write);
+
+    const policy1 = synchronizer.getProjectPolicy(storagePath);
+    assert.isObject(policy1);
+    assert.isTrue(policy1.valid);
+    assert.isNotEmpty(policy1.path);
+    assert.isNotEmpty(policy1.policy);
+
+    const suppressions1 = synchronizer.getRepositorySuppressions(storagePath);
+    assert.isArray(suppressions1);
+    assert.equal(suppressions1.length, 1);
+    assert.isTrue(suppressions1[0].isAccepted);
+
+    await synchronizer.synchronize({
+      accessToken: 'SAMPLE_TOKEN'
+    } as any, storagePath);
+
+    const info2 = synchronizer.getProjectInfo(storagePath);
+    assert.isNotEmpty(info2);
+    assert.equal(info2?.name, 'User1 Project')
+
+    const permissions2 = synchronizer.getProjectPermissions(storagePath);
+    assert.isObject(permissions2);
+    assert.isTrue(permissions2?.repositories.write);
+
+    const policy2 = synchronizer.getProjectPolicy(storagePath);
+    assert.isObject(policy2);
+    assert.isTrue(policy2.valid);
+    assert.isNotEmpty(policy2.path);
+    assert.isNotEmpty(policy2.policy);
+
+    const suppressions2 = synchronizer.getRepositorySuppressions(storagePath);
+    assert.isArray(suppressions2);
+    assert.equal(suppressions2.length, 2);
+    assert.isTrue(suppressions2[0].isAccepted);
+    assert.isTrue(suppressions2[1].isUnderReview);
+
+    await synchronizer.synchronize({
+      accessToken: 'SAMPLE_TOKEN'
+    } as any, storagePath);
+
+    const info3 = synchronizer.getProjectInfo(storagePath);
+    assert.isNotEmpty(info3);
+    assert.equal(info3?.name, 'User1 Project')
+
+    const permissions3 = synchronizer.getProjectPermissions(storagePath);
+    assert.isObject(permissions3);
+    assert.isTrue(permissions3?.repositories.write);
+
+    const policy3 = synchronizer.getProjectPolicy(storagePath);
+    assert.isObject(policy3);
+    assert.isTrue(policy3.valid);
+    assert.isNotEmpty(policy3.path);
+    assert.isNotEmpty(policy3.policy);
+
+    const suppressions3 = synchronizer.getRepositorySuppressions(storagePath);
+    assert.isArray(suppressions3);
+    assert.equal(suppressions3.length, 2);
+    assert.isTrue(suppressions3[0].isAccepted);
+    assert.isTrue(suppressions3[1].isUnderReview);
+
+    assert.equal(callsCounter.getUser, 3);
+    assert.equal(callsCounter.getProject, 3);
+    assert.equal(callsCounter.getPolicy, 1);
+    assert.equal(callsCounter.getSuppression, 3);
+  });
 });
 
 async function createTmpConfigDir(copyPolicyFixture = '') {
@@ -257,4 +226,220 @@ function createSynchronizer(storagePath: string, stubs: sinon.SinonStub[]) {
   stubs.push(getRootGitDataStub);
 
   return synchronizer;
+}
+
+function stubApi(synchronizer: any, stubs: SinonStub[]) {
+  const calls = {
+    getUser: 0,
+    getPolicy: 0,
+    getProject: 0,
+    getSuppression: 0,
+  }
+
+  const queryApiStub = sinon.stub(synchronizer._apiHandler, 'queryApi').callsFake(async (...args) => {
+    const query = args[0] as string;
+
+    if (query.includes('query getUser')) {
+      calls.getUser++;
+      return {
+        data: {
+          me: {
+            id: 1,
+            email: 'user1@kubeshop.io',
+            projects: [
+              {
+                project: {
+                  id: 1000,
+                  slug: 'user1-proj',
+                  name: 'User1 Project',
+                  repositories: [
+                    {
+                      id: 'user1-proj-policy-id',
+                      projectId: 1000,
+                      provider: 'GITHUB',
+                      owner: 'kubeshop',
+                      name: 'monokle-demo',
+                      prChecks: false,
+                      canEnablePrChecks: true,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      };
+    }
+
+    if (query.includes('query getPolicy')) {
+      calls.getPolicy++;
+      return {
+        data: {
+          getProject: {
+            id: 1000,
+            name: 'User1 Project',
+            policy: {
+              id: 'policy1',
+              json: {
+                plugins: {
+                  'pod-security-standards': true,
+                  'yaml-syntax': false,
+                  'resource-links': false,
+                  'kubernetes-schema': false,
+                  practices: true,
+                },
+                rules: {
+                  'pod-security-standards/host-process': 'err',
+                },
+                settings: {
+                  'kubernetes-schema': {
+                    schemaVersion: 'v1.27.1',
+                  },
+                },
+              },
+            },
+          }
+        }
+      }
+    }
+
+    if (query.includes('query getProject')) {
+      calls.getProject++;
+      return {
+        data: {
+          getProject: {
+            id: 1000,
+            slug: 'user1-proj',
+            name: 'User1 Project',
+            projectRepository: {
+              id: 'repo1',
+              projectId: 1000,
+              provider: 'GITHUB',
+              owner: 'kubeshop',
+              name: 'monokle-demo',
+            },
+            permissions: {
+              project: {
+                view: true,
+                update: true,
+                delete: true
+              },
+              members: {
+                view: true,
+                update: true,
+                delete: true
+              },
+              repositories: {
+                read: true,
+                write: true
+              }
+            },
+            policy: {
+              id: 'policy1',
+              updatedAt: '2024-02-08T12:15:10.298Z',
+            }
+          }
+        }
+      };
+    }
+
+    if (query.includes('query getSuppressions')) {
+      calls.getSuppression++;
+
+      if (calls.getSuppression === 1) {
+        return {
+          data: {
+            getSuppressions: {
+              data: [{
+                id: 'supp-1',
+                fingerprint: '16587e60761329',
+                description: 'K8S001 - Value at /spec/replicas should be integer',
+                location: 'blue-cms.deployment@bundles/simple.yaml@c9cf721b174f5-0',
+                status: 'ACCEPTED',
+                justification: null,
+                expiresAt: null,
+                updatedAt: '2024-02-01T13:32:10.445Z',
+                createdAt: '2024-02-01T13:32:10.445Z',
+                isUnderReview: false,
+                isAccepted: true,
+                isRejected: false,
+                isExpired: true,
+                isDeleted: false,
+                repositoryId: 'repo1',
+              }]
+            }
+          }
+        }
+      } else if (calls.getSuppression === 2) {
+        return {
+          data: {
+            getSuppressions: {
+              data: [{
+                id: 'supp-1',
+                fingerprint: '16587e60761329',
+                description: 'K8S001 - Value at /spec/replicas should be integer',
+                location: 'blue-cms.deployment@bundles/simple.yaml@c9cf721b174f5-0',
+                status: 'REJECTED',
+                justification: null,
+                expiresAt: null,
+                updatedAt: '2024-02-01T13:32:10.445Z',
+                createdAt: '2024-02-01T13:32:10.445Z',
+                isUnderReview: false,
+                isAccepted: false,
+                isRejected: true,
+                isExpired: true,
+                isDeleted: true,
+                repositoryId: 'repo1',
+              }, {
+                id: 'supp-2',
+                fingerprint: '16587e607613292',
+                description: 'K8S001 - Value at /spec/replicas should be integer',
+                location: 'blue-cms.deployment@bundles/simple.yaml@c9cf721b174f5-0',
+                status: 'ACCEPTED',
+                justification: null,
+                expiresAt: null,
+                updatedAt: '2024-02-01T13:32:10.445Z',
+                createdAt: '2024-02-01T13:32:10.445Z',
+                isUnderReview: false,
+                isAccepted: true,
+                isRejected: false,
+                isExpired: true,
+                isDeleted: false,
+                repositoryId: 'repo1',
+              }, {
+                id: 'supp-3',
+                fingerprint: '16587e607613292',
+                description: 'K8S001 - Value at /spec/replicas should be integer',
+                location: 'blue-cms.deployment@bundles/simple.yaml@c9cf721b174f5-0',
+                status: 'UNDER_REVIEW',
+                justification: null,
+                expiresAt: null,
+                updatedAt: '2024-02-01T13:32:10.445Z',
+                createdAt: '2024-02-01T13:32:10.445Z',
+                isUnderReview: true,
+                isAccepted: false,
+                isRejected: false,
+                isExpired: true,
+                isDeleted: false,
+                repositoryId: 'repo1',
+              }]
+            }
+          }
+        }
+      } else {
+        return {
+          data: {
+            getSuppressions: {
+              data: []
+            }
+          }
+        }
+      }
+    }
+
+    return {};
+  });
+  stubs.push(queryApiStub);
+
+  return calls;
 }

--- a/packages/synchronizer/src/createMonokleProjectSynchronizer.ts
+++ b/packages/synchronizer/src/createMonokleProjectSynchronizer.ts
@@ -2,19 +2,21 @@ import {DEFAULT_ORIGIN} from './constants.js';
 import {ApiHandler, ClientConfig} from './handlers/apiHandler.js';
 import {OriginConfig, fetchOriginConfig} from './handlers/configHandler.js';
 import {GitHandler} from './handlers/gitHandler.js';
+import {StorageHandlerJsonCache} from './handlers/storageHandlerJsonCache.js';
 import {StorageHandlerPolicy} from './handlers/storageHandlerPolicy.js';
 import {ProjectSynchronizer} from './utils/projectSynchronizer.js';
 
 export async function createMonokleProjectSynchronizerFromOrigin(
   clientConfig: ClientConfig,
   origin: string = DEFAULT_ORIGIN,
-  storageHandler: StorageHandlerPolicy = new StorageHandlerPolicy(),
+  storageHandlerPolicy: StorageHandlerPolicy = new StorageHandlerPolicy(),
+  storageHandlerJsonCache: StorageHandlerJsonCache = new StorageHandlerJsonCache(),
   gitHandler: GitHandler = new GitHandler()
 ) {
   try {
     const originConfig = await fetchOriginConfig(origin);
 
-    return createMonokleProjectSynchronizerFromConfig(clientConfig, originConfig, storageHandler, gitHandler);
+    return createMonokleProjectSynchronizerFromConfig(clientConfig, originConfig, storageHandlerPolicy, storageHandlerJsonCache, gitHandler);
   } catch (err: any) {
     throw err;
   }
@@ -23,12 +25,13 @@ export async function createMonokleProjectSynchronizerFromOrigin(
 export function createMonokleProjectSynchronizerFromConfig(
   clientConfig: ClientConfig,
   originConfig: OriginConfig,
-  storageHandler: StorageHandlerPolicy = new StorageHandlerPolicy(),
+  storageHandlerPolicy: StorageHandlerPolicy = new StorageHandlerPolicy(),
+  storageHandlerJsonCache: StorageHandlerJsonCache = new StorageHandlerJsonCache(),
   gitHandler: GitHandler = new GitHandler()
 ) {
   if (!originConfig?.apiOrigin) {
     throw new Error(`No api origin found in origin config from ${origin}.`);
   }
 
-  return new ProjectSynchronizer(storageHandler, new ApiHandler(originConfig, clientConfig), gitHandler);
+  return new ProjectSynchronizer(storageHandlerPolicy, storageHandlerJsonCache, new ApiHandler(originConfig, clientConfig), gitHandler);
 }

--- a/packages/synchronizer/src/createMonokleProjectSynchronizer.ts
+++ b/packages/synchronizer/src/createMonokleProjectSynchronizer.ts
@@ -1,0 +1,34 @@
+import {DEFAULT_ORIGIN} from './constants.js';
+import {ApiHandler, ClientConfig} from './handlers/apiHandler.js';
+import {OriginConfig, fetchOriginConfig} from './handlers/configHandler.js';
+import {GitHandler} from './handlers/gitHandler.js';
+import {StorageHandlerPolicy} from './handlers/storageHandlerPolicy.js';
+import {ProjectSynchronizer} from './utils/projectSynchronizer.js';
+
+export async function createMonokleProjectSynchronizerFromOrigin(
+  clientConfig: ClientConfig,
+  origin: string = DEFAULT_ORIGIN,
+  storageHandler: StorageHandlerPolicy = new StorageHandlerPolicy(),
+  gitHandler: GitHandler = new GitHandler()
+) {
+  try {
+    const originConfig = await fetchOriginConfig(origin);
+
+    return createMonokleProjectSynchronizerFromConfig(clientConfig, originConfig, storageHandler, gitHandler);
+  } catch (err: any) {
+    throw err;
+  }
+}
+
+export function createMonokleProjectSynchronizerFromConfig(
+  clientConfig: ClientConfig,
+  originConfig: OriginConfig,
+  storageHandler: StorageHandlerPolicy = new StorageHandlerPolicy(),
+  gitHandler: GitHandler = new GitHandler()
+) {
+  if (!originConfig?.apiOrigin) {
+    throw new Error(`No api origin found in origin config from ${origin}.`);
+  }
+
+  return new ProjectSynchronizer(storageHandler, new ApiHandler(originConfig, clientConfig), gitHandler);
+}

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -403,7 +403,7 @@ export class ApiHandler {
   }
 
   async toggleSuppression(fingerprint: string, repoId: string, description: string, tokenInfo: TokenInfo) {
-    return this.queryApi<ApiSuppression>(toggleSuppressionMutation, tokenInfo, {fingerprint, repoId, description});
+    return this.queryApi<ApiSuppressionsData>(toggleSuppressionMutation, tokenInfo, {fingerprint, repoId, description});
   }
 
   generateDeepLink(path: string) {

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -137,12 +137,19 @@ const getSuppressionsQuery = `
       data {
         id
         fingerprint
+        description
+        location
         status
+        justification
+        expiresAt
+        updatedAt
+        createdAt
         isUnderReview
         isAccepted
         isRejected
         isExpired
         isDeleted
+        repositoryId
       }
     }
   }
@@ -154,6 +161,30 @@ const getRepoIdQuery = `
       repository(input: { name: $repoName, owner: $repoOwner }) {
         id
       }
+    }
+  }
+`;
+
+const toggleSuppressionMutation = `
+  mutation toggleSuppression($fingerprint: String!, $repoId: ID!, $description: String!) {
+    toggleSuppression(
+      input: {fingerprint: $fingerprint, repository: $repoId, description: $description, skipReview: true}
+    ) {
+      id
+      fingerprint
+      description
+      location
+      status
+      justification
+      expiresAt
+      updatedAt
+      createdAt
+      isUnderReview
+      isAccepted
+      isRejected
+      isExpired
+      isDeleted
+      repositoryId
     }
   }
 `;
@@ -211,12 +242,19 @@ export type ApiPolicyData = {
 export type ApiSuppression = {
   id: string;
   fingerprint: string;
+  description: string;
+  locations: string;
   status: SuppressionStatus;
+  justification: string;
+  expiresAt: string;
+  updatedAt: string;
+  createdAt: string;
   isUnderReview: boolean;
   isAccepted: boolean;
   isRejected: boolean;
   isExpired: boolean;
   isDeleted: boolean;
+  repositoryId: string;
 };
 
 export type ApiSuppressionsData = {
@@ -362,6 +400,10 @@ export class ApiHandler {
     tokenInfo: TokenInfo
   ): Promise<ApiRepoIdData | undefined> {
     return this.queryApi(getRepoIdQuery, tokenInfo, {projectSlug, repoOwner, repoName});
+  }
+
+  async toggleSuppression(fingerprint: string, repoId: string, description: string, tokenInfo: TokenInfo) {
+    return this.queryApi<ApiSuppression>(toggleSuppressionMutation, tokenInfo, {fingerprint, repoId, description});
   }
 
   generateDeepLink(path: string) {

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -84,19 +84,6 @@ const getProjectDetailsQuery = `
         provider
         owner
         name
-        suppressions {
-          id
-          fingerprint
-          description
-          status
-          justification
-          expiresAt
-          isUnderReview
-          isAccepted
-          isRejected
-          isExpired
-          isDeleted
-        }
       }
       permissions {
         project {
@@ -116,7 +103,7 @@ const getProjectDetailsQuery = `
       }
       policy {
         id
-        json
+        updatedAt
       }
     }
   }
@@ -137,11 +124,13 @@ const getPolicyQuery = `
 
 const getSuppressionsQuery = `
   query getSuppressions(
-    $repositoryId: ID!
+    $repositoryId: ID!,
+    $from: String
   ) {
     getSuppressions(
       input: {
-        repositoryId: $repositoryId
+        repositoryId: $repositoryId,
+        from: $from
       }
     ) {
       isSnapshot
@@ -287,13 +276,11 @@ export type ApiProjectDetailsData = {
       id: number;
       slug: string;
       name: string;
-      projectRepository: ApiUserProjectRepo & {
-        suppressions: (ApiSuppression & {justification: string; expiresAt: string;})[];
-      };
+      projectRepository: ApiUserProjectRepo;
       permissions: ApiProjectPermissions;
       policy: {
         id: string;
-        json: any;
+        updatedAt: string;
       }
     }
   }
@@ -364,8 +351,8 @@ export class ApiHandler {
     return this.queryApi(getPolicyQuery, tokenInfo, {slug});
   }
 
-  async getSuppressions(repositoryId: string, tokenInfo: TokenInfo): Promise<ApiSuppressionsData | undefined> {
-    return this.queryApi(getSuppressionsQuery, tokenInfo, {repositoryId});
+  async getSuppressions(repositoryId: string, tokenInfo: TokenInfo, from?: string): Promise<ApiSuppressionsData | undefined> {
+    return this.queryApi(getSuppressionsQuery, tokenInfo, {repositoryId, from});
   }
 
   async getRepoId(

--- a/packages/synchronizer/src/handlers/storageHandler.ts
+++ b/packages/synchronizer/src/handlers/storageHandler.ts
@@ -41,7 +41,7 @@ export abstract class StorageHandler<TData> {
 
     try {
       const data = readFileSync(file, 'utf8');
-      const config = parse(data);
+      const config = this.parseData(data);
       return config;
     } catch (err: any) {
       throw new Error(`Failed to read configuration from '${file}' with error: ${err.message}`);
@@ -55,7 +55,7 @@ export abstract class StorageHandler<TData> {
 
     try {
       const data = await readFile(file, 'utf8');
-      const config = parse(data);
+      const config = this.parseData(data);
       return config;
     } catch (err: any) {
       throw new Error(`Failed to read configuration from '${file}' with error: ${err.message}`);
@@ -71,6 +71,10 @@ export abstract class StorageHandler<TData> {
     } catch (err: any) {
       throw new Error(`Failed to write configuration to '${file}' with error: ${err.message} and data: ${data}`);
     }
+  }
+
+  protected parseData(data: string) {
+    return parse(data);
   }
 }
 

--- a/packages/synchronizer/src/handlers/storageHandlerJsonCache.ts
+++ b/packages/synchronizer/src/handlers/storageHandlerJsonCache.ts
@@ -1,0 +1,17 @@
+import {StorageHandler, getDefaultStorageConfigPaths} from './storageHandler.js';
+
+export class StorageHandlerJsonCache extends StorageHandler<Record<string, any>> {
+  constructor(storageFolderPath: string = getDefaultStorageConfigPaths().cache) {
+    super(storageFolderPath);
+  }
+
+  async setStoreData(data: Record<string, any>, fileName: string): Promise<string | undefined> {
+    const filePath = this.getStoreDataFilePath(fileName);
+    await this.writeStoreData(filePath, JSON.stringify(data));
+    return filePath;
+  }
+
+  protected parseData(data: string) {
+    return JSON.parse(data);
+  }
+}

--- a/packages/synchronizer/src/index.ts
+++ b/packages/synchronizer/src/index.ts
@@ -4,6 +4,7 @@ export * from './handlers/deviceFlowHandler.js';
 export * from './handlers/gitHandler.js';
 export * from './handlers/storageHandler.js';
 export * from './handlers/storageHandlerAuth.js';
+export * from './handlers/storageHandlerJsonCache.js'
 export * from './handlers/storageHandlerPolicy.js';
 
 export * from './models/user.js';

--- a/packages/synchronizer/src/index.ts
+++ b/packages/synchronizer/src/index.ts
@@ -11,6 +11,7 @@ export * from './models/user.js';
 export * from './utils/authenticator.js';
 export * from './utils/fetcher.js';
 export * from './utils/synchronizer.js';
+export * from './utils/projectSynchronizer.js';
 
 export * from './constants.js';
 

--- a/packages/synchronizer/src/index.ts
+++ b/packages/synchronizer/src/index.ts
@@ -21,3 +21,4 @@ export * from './createDefaultMonokleSynchronizer.js';
 export * from './createMonokleAuthenticator.js';
 export * from './createMonokleFetcher.js';
 export * from './createMonokleSynchronizer.js';
+export * from './createMonokleProjectSynchronizer.js';

--- a/packages/synchronizer/src/utils/projectSynchronizer.ts
+++ b/packages/synchronizer/src/utils/projectSynchronizer.ts
@@ -2,40 +2,56 @@ import slugify from 'slugify';
 import {EventEmitter} from 'events';
 import {normalize} from 'path';
 import {StorageHandlerPolicy, StoragePolicyFormat} from '../handlers/storageHandlerPolicy.js';
+import {StorageHandlerJsonCache} from '../handlers/storageHandlerJsonCache.js';
 import {ApiHandler} from '../handlers/apiHandler.js';
 import {GitHandler} from '../handlers/gitHandler.js';
-import type {ApiProjectDetailsData, ApiProjectPermissions, ApiUserProject} from '../handlers/apiHandler.js';
+import type {ApiPolicyData, ApiProjectPermissions, ApiSuppression, ApiSuppressionsData, ApiUserProject, ApiUserProjectRepo} from '../handlers/apiHandler.js';
 import type {TokenInfo} from '../handlers/storageHandlerAuth.js';
-import type {ProjectInfo, RepoRemoteInputData} from './synchronizer.js';
+import type {RepoRemoteInputData} from './synchronizer.js';
+import type {ValidationConfig} from '@monokle/types';
+
+export type CacheMetadata = {
+  suppressionsLastFetchDate: string;
+  policyLastUpdatedAt: string;
+  projectSlug: string;
+};
+
+export type ProjectDataCache = {
+  project: {
+    id: number;
+    slug: string;
+    name: string;
+  },
+  permissions: ApiProjectPermissions;
+  repository: ApiUserProjectRepo;
+  suppressions: ApiSuppression[];
+  policy: ValidationConfig;
+};
 
 export class ProjectSynchronizer extends EventEmitter {
-  private _dataCache: Record<string, ApiProjectDetailsData['data']['getProject']> = {};
+  private _dataCache: Record<string, ProjectDataCache> = {};
   private _pathToRepoMap: Record<string, RepoRemoteInputData> = {};
 
   constructor(
-    private _storageHandler: StorageHandlerPolicy,
+    private _storageHandlerPolicy: StorageHandlerPolicy,
+    private _storageHandlerJsonCache: StorageHandlerJsonCache,
     private _apiHandler: ApiHandler,
     private _gitHandler: GitHandler
   ) {
     super();
   }
 
-  getProjectInfo(rootPath: string, projectSlug?: string): ProjectInfo | undefined {
+  getProjectInfo(rootPath: string, projectSlug?: string) {
     const cached = this._dataCache[this.getCacheId(rootPath, projectSlug)];
-
-    return cached ? {
-      slug: cached.slug,
-      name: cached.name,
-      id: cached.id,
-    } : undefined;
+    return cached?.project ?? undefined;
   }
 
-  getProjectPermissions(rootPath: string, projectSlug?: string): ApiProjectPermissions | undefined {
+  getProjectPermissions(rootPath: string, projectSlug?: string) {
     return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.permissions;
   }
 
   getRepositorySuppressions(rootPath: string, projectSlug?: string) {
-    return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.projectRepository.suppressions ?? [];
+    return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.suppressions ?? [];
   }
 
   getProjectPolicy(rootPath: string, projectSlug?: string) {
@@ -47,7 +63,7 @@ export class ProjectSynchronizer extends EventEmitter {
       return {
         valid: true,
         path: this.getPolicyPath(repoData),
-        policy: cached.policy.json,
+        policy: cached.policy,
       };
     }
 
@@ -63,10 +79,10 @@ export class ProjectSynchronizer extends EventEmitter {
       throw new Error('Cannot fetch data without access token.');
     }
 
-    const cacheId = this.getCacheId(rootPath, projectSlug);
     const repoData = await this.getRootGitData(rootPath);
     const ownerProjectSlug = projectSlug ?? (await this.getMatchingProject(repoData, tokenInfo))?.slug;
 
+    const cacheId = this.getCacheId(rootPath, projectSlug);
     this._pathToRepoMap[cacheId] = {
       ...repoData,
       ownerProjectSlug: projectSlug,
@@ -80,34 +96,103 @@ export class ProjectSynchronizer extends EventEmitter {
     }
 
     if (ownerProjectSlug && repoData?.owner && repoData?.name && repoData?.provider) {
-      const projectDetails = await this._apiHandler.getProjectDetails({
-        slug: ownerProjectSlug,
-        owner: repoData.owner,
-        name: repoData.name,
-        provider: repoData.provider,
-      }, tokenInfo);
-
-      const policyUrl = this._apiHandler.generateDeepLink(`/dashboard/projects/${ownerProjectSlug}/policy`);
+      const projectDetails = await this.refetchProjectDetails(repoData, ownerProjectSlug, tokenInfo);
       if (!projectDetails?.data?.getProject?.policy) {
+        const policyUrl = this._apiHandler.generateDeepLink(`/dashboard/projects/${ownerProjectSlug}/policy`);
         throw new Error(
           `The '${rootPath}' repository project does not have policy defined. Configure it on ${policyUrl}.`
         );
       }
 
-      this._dataCache[cacheId] = projectDetails?.data?.getProject;
+      const projectValidationData = await this.refetchProjectValidationData(
+        repoData,
+        projectDetails.data.getProject.projectRepository.id,
+        projectDetails.data.getProject.policy.updatedAt,
+        ownerProjectSlug,
+        tokenInfo
+      );
 
-      const policyContent: StoragePolicyFormat = projectDetails.data.getProject.policy.json;
-      const comment = [
-        ` This is remote policy downloaded from ${this._apiHandler.apiUrl}.`,
-        ` You can adjust it on ${policyUrl}.`,
-      ].join('\n');
+      const cachedSuppressionsFile = this.getSuppressionsFileName(repoData);
+      const cachedSuppressions = (await this._storageHandlerJsonCache.getStoreData(cachedSuppressionsFile) ?? []) as ApiSuppression[];
+      const dataCache: ProjectDataCache = {
+        project: {
+          id: projectDetails.data.getProject.id,
+          slug: projectDetails.data.getProject.slug,
+          name: projectDetails.data.getProject.name,
+        },
+        permissions: projectDetails.data.getProject.permissions,
+        repository: projectDetails.data.getProject.projectRepository,
+        suppressions: cachedSuppressions,
+        policy: {}
+      };
 
-      const policyPath = await this.storePolicy(policyContent, this._pathToRepoMap[cacheId], comment);
-      if (!policyPath) {
-        throw new Error(`Error storing policy in local filesystem.`);
+      if (projectValidationData.suppressions.length) {
+        // @TODO What about modified suppressions? We should probably check by id and replace?
+        const allSuppressions = [...cachedSuppressions, ...projectValidationData.suppressions];
+        this._storageHandlerJsonCache.setStoreData(allSuppressions, cachedSuppressionsFile);
+        dataCache.suppressions = allSuppressions;
       }
 
+      if (projectValidationData.policy?.json) {
+        const policyContent: StoragePolicyFormat = projectValidationData.policy.json;
+        const policyUrl = this._apiHandler.generateDeepLink(`/dashboard/projects/${ownerProjectSlug}/policy`);
+        const comment = [
+          ` This is remote policy downloaded from ${this._apiHandler.apiUrl}.`,
+          ` You can adjust it on ${policyUrl}.`,
+        ].join('\n');
+
+        const policyPath = await this.storePolicy(policyContent, this._pathToRepoMap[cacheId], comment);
+        if (!policyPath) {
+          throw new Error(`Error storing policy in local filesystem.`);
+        }
+
+        dataCache.policy = projectValidationData.policy.json;
+      } else {
+        dataCache.policy = await this.readPolicy(repoData) ?? {};
+      }
+
+      this._dataCache[cacheId] = dataCache;
+
       this.emit('synchronized');
+    }
+  }
+
+  private async refetchProjectDetails(repoData: RepoRemoteInputData, ownerProjectSlug: string, tokenInfo: TokenInfo) {
+    return this._apiHandler.getProjectDetails({
+      slug: ownerProjectSlug,
+      owner: repoData.owner,
+      name: repoData.name,
+      provider: repoData.provider,
+    }, tokenInfo);
+  }
+
+  private async refetchProjectValidationData(repoData: RepoRemoteInputData, repoId: string, policyUpdatedAt: string, ownerProjectSlug: string, tokenInfo: TokenInfo) {
+    const cacheFile = this.getMetadataFileName(repoData);
+    const cacheMetadata = await this._storageHandlerJsonCache.getStoreData(cacheFile) as CacheMetadata;
+    const isCachedProjectMatching = ownerProjectSlug === cacheMetadata?.projectSlug;
+
+    const newSuppressionsLastFetchDate = (new Date()).toISOString();
+    const fetchSuppressionsFrom = isCachedProjectMatching ? cacheMetadata?.suppressionsLastFetchDate : undefined;
+
+    const dataRefetchQueries: Promise<any>[] = [
+      this._apiHandler.getSuppressions(repoId, tokenInfo, fetchSuppressionsFrom)
+    ];
+    if (!isCachedProjectMatching || !cacheMetadata?.policyLastUpdatedAt || cacheMetadata.policyLastUpdatedAt !== policyUpdatedAt) {
+      dataRefetchQueries.push(this._apiHandler.getPolicy(ownerProjectSlug, tokenInfo));
+    }
+
+    const newData = await Promise.all(dataRefetchQueries);
+
+    const newCacheMetadata: CacheMetadata = {
+      suppressionsLastFetchDate: newSuppressionsLastFetchDate,
+      policyLastUpdatedAt: policyUpdatedAt,
+      projectSlug: ownerProjectSlug
+    };
+    this._storageHandlerJsonCache.setStoreData(newCacheMetadata, cacheFile);
+
+    return {
+      suppressions: (newData[0] as ApiSuppressionsData | undefined)?.data?.getSuppressions?.data ?? [],
+      policy: (newData[1] as ApiPolicyData | undefined)?.data?.getProject?.policy,
     }
   }
 
@@ -140,20 +225,20 @@ export class ProjectSynchronizer extends EventEmitter {
     return (repoMatchingProjectBySlug ?? repoFirstProject)?.project ?? null;
   }
 
-  private getPolicyPath(repoData: RepoRemoteInputData) {
-    return this._storageHandler.getStoreDataFilePath(this.getPolicyFileName(repoData));
-  }
-
   private async storePolicy(
     policyContent: StoragePolicyFormat,
     repoData: RepoRemoteInputData,
     comment: string
   ) {
-    return this._storageHandler.setStoreData(policyContent, this.getPolicyFileName(repoData), comment);
+    return this._storageHandlerPolicy.setStoreData(policyContent, this.getPolicyFileName(repoData), comment);
   }
 
   private async readPolicy(inputData: RepoRemoteInputData) {
-    return this._storageHandler.getStoreData(this.getPolicyFileName(inputData));
+    return this._storageHandlerPolicy.getStoreData(this.getPolicyFileName(inputData));
+  }
+
+  private getPolicyPath(inputData: RepoRemoteInputData) {
+    return this._storageHandlerPolicy.getStoreDataFilePath(this.getPolicyFileName(inputData));
   }
 
   private async getRootGitData(rootPath: string) {
@@ -170,6 +255,18 @@ export class ProjectSynchronizer extends EventEmitter {
   }
 
   private getPolicyFileName(repoData: RepoRemoteInputData) {
+    return this.getFileName(repoData, 'policy');
+  }
+
+  private getSuppressionsFileName(repoData: RepoRemoteInputData) {
+    return this.getFileName(repoData, 'suppressions');
+  }
+
+  private getMetadataFileName(repoData: RepoRemoteInputData) {
+    return this.getFileName(repoData, 'metadata');
+  }
+
+  private getFileName(repoData: RepoRemoteInputData, suffix: string, ext = 'yaml') {
     const provider = slugify(repoData.provider, {
       replacement: '_',
       lower: true,
@@ -178,6 +275,6 @@ export class ProjectSynchronizer extends EventEmitter {
       trim: true,
     });
 
-    return `${provider}-${repoData.owner}-${repoData.name}.policy.yaml`;
+    return `${provider}-${repoData.owner}-${repoData.name}.${suffix}.${ext}`;
   }
 }

--- a/packages/synchronizer/src/utils/projectSynchronizer.ts
+++ b/packages/synchronizer/src/utils/projectSynchronizer.ts
@@ -112,6 +112,8 @@ export class ProjectSynchronizer extends EventEmitter {
       if (!policyPath) {
         throw new Error(`Error storing policy in local filesystem.`);
       }
+
+      this.emit('synchronized');
     }
   }
 

--- a/packages/synchronizer/src/utils/projectSynchronizer.ts
+++ b/packages/synchronizer/src/utils/projectSynchronizer.ts
@@ -4,9 +4,9 @@ import {normalize} from 'path';
 import {StorageHandlerPolicy, StoragePolicyFormat} from '../handlers/storageHandlerPolicy.js';
 import {ApiHandler} from '../handlers/apiHandler.js';
 import {GitHandler} from '../handlers/gitHandler.js';
-import type {ApiProjectDetailsData, ApiUserProject} from '../handlers/apiHandler.js';
+import type {ApiProjectDetailsData, ApiProjectPermissions, ApiUserProject} from '../handlers/apiHandler.js';
 import type {TokenInfo} from '../handlers/storageHandlerAuth.js';
-import type {RepoRemoteInputData} from './synchronizer.js';
+import type {ProjectInfo, RepoRemoteInputData} from './synchronizer.js';
 
 export class ProjectSynchronizer extends EventEmitter {
   private _dataCache: Record<string, ApiProjectDetailsData['data']['getProject']> = {};
@@ -20,7 +20,7 @@ export class ProjectSynchronizer extends EventEmitter {
     super();
   }
 
-  getProjectInfo(rootPath: string, projectSlug?: string) {
+  getProjectInfo(rootPath: string, projectSlug?: string): ProjectInfo | undefined {
     const cached = this._dataCache[this.getCacheId(rootPath, projectSlug)];
 
     return cached ? {
@@ -30,7 +30,7 @@ export class ProjectSynchronizer extends EventEmitter {
     } : undefined;
   }
 
-  getProjectPermissions(rootPath: string, projectSlug?: string) {
+  getProjectPermissions(rootPath: string, projectSlug?: string): ApiProjectPermissions | undefined {
     return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.permissions;
   }
 
@@ -57,11 +57,15 @@ export class ProjectSynchronizer extends EventEmitter {
       };
     }
 
-    return undefined;
+    return {
+      valid: false,
+      path: '',
+      policy: undefined,
+    };
   }
 
   getRepositorySuppressions(rootPath: string, projectSlug?: string) {
-    return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.projectRepository.suppressions;
+    return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.projectRepository.suppressions ?? [];
   }
 
   async synchronize(tokenInfo: TokenInfo, rootPath: string, projectSlug?: string): Promise<void> {

--- a/packages/synchronizer/src/utils/projectSynchronizer.ts
+++ b/packages/synchronizer/src/utils/projectSynchronizer.ts
@@ -106,9 +106,9 @@ export class ProjectSynchronizer extends EventEmitter {
     }
 
     const suppressionResult = await this._apiHandler.toggleSuppression(fingerprint, id, description, tokenInfo);
-    if (suppressionResult) {
+    if (suppressionResult?.data?.getSuppressions?.data?.length) {
         const existingSuppressions = await this.readSuppressions(repoData);
-        const allSuppressions = this.mergeSuppressions(existingSuppressions, [suppressionResult]);
+        const allSuppressions = this.mergeSuppressions(existingSuppressions, suppressionResult.data.getSuppressions.data);
         await this.storeSuppressions(allSuppressions, repoData);
 
         const cacheId = this.getCacheId(rootPath, projectSlug);
@@ -319,7 +319,8 @@ export class ProjectSynchronizer extends EventEmitter {
       suppressionsMap[suppression.id] = suppression;
     });
 
-    return Object.values(suppressionsMap);
+    return Object.values(suppressionsMap)
+      .filter(suppression => !(suppression.isDeleted || suppression.isRejected));
   }
 
   private async storeCacheMetadata(cacheMetadata: CacheMetadata, repoData: RepoRemoteInputData) {

--- a/packages/synchronizer/src/utils/projectSynchronizer.ts
+++ b/packages/synchronizer/src/utils/projectSynchronizer.ts
@@ -1,0 +1,187 @@
+import slugify from 'slugify';
+import {EventEmitter} from 'events';
+import {normalize} from 'path';
+import {StorageHandlerPolicy, StoragePolicyFormat} from '../handlers/storageHandlerPolicy.js';
+import {ApiHandler} from '../handlers/apiHandler.js';
+import {GitHandler} from '../handlers/gitHandler.js';
+import type {ApiProjectDetailsData, ApiUserProject} from '../handlers/apiHandler.js';
+import type {TokenInfo} from '../handlers/storageHandlerAuth.js';
+import type {RepoRemoteInputData} from './synchronizer.js';
+
+export class ProjectSynchronizer extends EventEmitter {
+  private _dataCache: Record<string, ApiProjectDetailsData['data']['getProject']> = {};
+  private _pathToRepoMap: Record<string, RepoRemoteInputData> = {};
+
+  constructor(
+    private _storageHandler: StorageHandlerPolicy,
+    private _apiHandler: ApiHandler,
+    private _gitHandler: GitHandler
+  ) {
+    super();
+  }
+
+  getProjectInfo(rootPath: string, projectSlug?: string) {
+    const cached = this._dataCache[this.getCacheId(rootPath, projectSlug)];
+
+    return cached ? {
+      slug: cached.slug,
+      name: cached.name,
+      id: cached.id,
+    } : undefined;
+  }
+
+  getProjectPermissions(rootPath: string, projectSlug?: string) {
+    return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.permissions;
+  }
+
+  getProjectPolicy(rootPath: string, projectSlug?: string) {
+    const cacheId = this.getCacheId(rootPath, projectSlug);
+    const cached = this._dataCache[cacheId];
+    const repoData = this._pathToRepoMap[cacheId];
+    const policyPath = this.getPolicyPath(repoData);
+
+    if (cached) {
+      return {
+        valid: true,
+        path: policyPath,
+        policy: cached.policy.json,
+      };
+    }
+
+    const stored = this.readPolicy(repoData);
+    if (stored) {
+      return {
+        valid: true,
+        path: policyPath,
+        policy: stored,
+      };
+    }
+
+    return undefined;
+  }
+
+  getRepositorySuppressions(rootPath: string, projectSlug?: string) {
+    return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.projectRepository.suppressions;
+  }
+
+  async synchronize(tokenInfo: TokenInfo, rootPath: string, projectSlug?: string): Promise<void> {
+    if (!tokenInfo || tokenInfo?.accessToken?.length === 0) {
+      throw new Error('Cannot fetch without access token.');
+    }
+
+    const cacheId = this.getCacheId(rootPath, projectSlug);
+    const repoData = await this.getRootGitData(rootPath);
+    const ownerProjectSlug = projectSlug ?? (await this.getMatchingProject(repoData, tokenInfo))?.slug;
+
+    this._pathToRepoMap[cacheId] = {
+      ...repoData,
+      ownerProjectSlug: projectSlug,
+    };
+
+    if (!ownerProjectSlug) {
+      const projectUrl = this._apiHandler.generateDeepLink(`/dashboard/projects`);
+      throw new Error(
+        `The '${rootPath}' repository does not belong to any project in Monokle Cloud. Configure it on ${projectUrl}.`
+      );
+    }
+
+    if (ownerProjectSlug && repoData?.owner && repoData?.name && repoData?.provider) {
+      const projectDetails = await this._apiHandler.getProjectDetails({
+        slug: ownerProjectSlug,
+        owner: repoData.owner,
+        name: repoData.name,
+        provider: repoData.provider,
+      }, tokenInfo);
+
+      const policyUrl = this._apiHandler.generateDeepLink(`/dashboard/projects/${ownerProjectSlug}/policy`);
+      if (!projectDetails?.data?.getProject?.policy) {
+        throw new Error(
+          `The '${rootPath}' repository project does not have policy defined. Configure it on ${policyUrl}.`
+        );
+      }
+
+      this._dataCache[cacheId] = projectDetails?.data?.getProject;
+
+      const policyContent: StoragePolicyFormat = projectDetails.data.getProject.policy.json;
+      const comment = [
+        ` This is remote policy downloaded from ${this._apiHandler.apiUrl}.`,
+        ` You can adjust it on ${policyUrl}.`,
+      ].join('\n');
+
+      const policyPath = await this.storePolicy(policyContent, this._pathToRepoMap[cacheId], comment);
+      if (!policyPath) {
+        throw new Error(`Error storing policy in local filesystem.`);
+      }
+    }
+  }
+
+  private async getMatchingProject(
+    repoData: RepoRemoteInputData,
+    tokenInfo: TokenInfo
+  ): Promise<ApiUserProject | null> {
+    const userData = await this._apiHandler.getUser(tokenInfo);
+    if (!userData?.data?.me) {
+      throw new Error('Cannot fetch user data, make sure you are authenticated and have internet access.');
+    }
+
+    if (!repoData?.provider || !repoData?.owner || !repoData?.name) {
+      throw new Error(`Provided invalid git repository data: '${JSON.stringify(repoData)}'.`);
+    }
+
+    const repoMatchingProjectBySlug = userData.data.me.projects.find(project => {
+      return project.project.slug === repoData.ownerProjectSlug;
+    });
+
+    const repoFirstProject = userData.data.me.projects.find(project => {
+      return project.project.repositories.find(
+        repo =>
+          repo.owner.toLowerCase() === repoData.owner.toLowerCase() &&
+          repo.name.toLowerCase() === repoData.name.toLowerCase() &&
+          repo.provider.toLowerCase() === repoData.provider.toLowerCase()
+      );
+    });
+
+    return (repoMatchingProjectBySlug ?? repoFirstProject)?.project ?? null;
+  }
+
+  private getPolicyPath(repoData: RepoRemoteInputData) {
+    return this._storageHandler.getStoreDataFilePath(this.getPolicyFileName(repoData));
+  }
+
+  private async storePolicy(
+    policyContent: StoragePolicyFormat,
+    repoData: RepoRemoteInputData,
+    comment: string
+  ) {
+    return this._storageHandler.setStoreData(policyContent, this.getPolicyFileName(repoData), comment);
+  }
+
+  private async readPolicy(inputData: RepoRemoteInputData) {
+    return this._storageHandler.getStoreData(this.getPolicyFileName(inputData));
+  }
+
+  private async getRootGitData(rootPath: string) {
+    const repoData = await this._gitHandler.getRepoRemoteData(rootPath);
+    if (!repoData) {
+      throw new Error(`The '${rootPath}' is not a git repository or does not have any remotes.`);
+    }
+
+    return repoData;
+  }
+
+   private getCacheId(rootPath: string, projectSlug?: string) {
+    return `${normalize(rootPath)}${projectSlug ? `+${projectSlug}` : ''}`;
+  }
+
+  private getPolicyFileName(repoData: RepoRemoteInputData) {
+    const provider = slugify(repoData.provider, {
+      replacement: '_',
+      lower: true,
+      strict: true,
+      locale: 'en',
+      trim: true,
+    });
+
+    return `${provider}-${repoData.owner}-${repoData.name}.policy.yaml`;
+  }
+}

--- a/packages/synchronizer/src/utils/projectSynchronizer.ts
+++ b/packages/synchronizer/src/utils/projectSynchronizer.ts
@@ -34,43 +34,33 @@ export class ProjectSynchronizer extends EventEmitter {
     return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.permissions;
   }
 
+  getRepositorySuppressions(rootPath: string, projectSlug?: string) {
+    return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.projectRepository.suppressions ?? [];
+  }
+
   getProjectPolicy(rootPath: string, projectSlug?: string) {
     const cacheId = this.getCacheId(rootPath, projectSlug);
     const cached = this._dataCache[cacheId];
     const repoData = this._pathToRepoMap[cacheId];
-    const policyPath = this.getPolicyPath(repoData);
 
-    if (cached) {
+    if (cached && repoData) {
       return {
         valid: true,
-        path: policyPath,
+        path: this.getPolicyPath(repoData),
         policy: cached.policy.json,
-      };
-    }
-
-    const stored = this.readPolicy(repoData);
-    if (stored) {
-      return {
-        valid: true,
-        path: policyPath,
-        policy: stored,
       };
     }
 
     return {
       valid: false,
       path: '',
-      policy: undefined,
+      policy: '',
     };
   }
 
-  getRepositorySuppressions(rootPath: string, projectSlug?: string) {
-    return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.projectRepository.suppressions ?? [];
-  }
-
   async synchronize(tokenInfo: TokenInfo, rootPath: string, projectSlug?: string): Promise<void> {
-    if (!tokenInfo || tokenInfo?.accessToken?.length === 0) {
-      throw new Error('Cannot fetch without access token.');
+    if (!tokenInfo?.accessToken?.length) {
+      throw new Error('Cannot fetch data without access token.');
     }
 
     const cacheId = this.getCacheId(rootPath, projectSlug);

--- a/packages/synchronizer/src/utils/projectSynchronizer.ts
+++ b/packages/synchronizer/src/utils/projectSynchronizer.ts
@@ -199,6 +199,12 @@ export class ProjectSynchronizer extends EventEmitter {
     }
   }
 
+  async forceSynchronize(tokenInfo: TokenInfo, rootPath: string, projectSlug?: string): Promise<void> {
+    const repoData = await this.getRootGitData(rootPath);
+    await this.dropCacheMetadata(repoData);
+    return this.synchronize(tokenInfo, rootPath, projectSlug);
+  }
+
   private async refetchProjectDetails(repoData: RepoRemoteInputData, ownerProjectSlug: string, tokenInfo: TokenInfo) {
     return this._apiHandler.getProjectDetails({
       slug: ownerProjectSlug,
@@ -322,6 +328,10 @@ export class ProjectSynchronizer extends EventEmitter {
 
   private async readCacheMetadata(repoData: RepoRemoteInputData) {
     return (await this._storageHandlerJsonCache.getStoreData(this.getMetadataFileName(repoData)) ?? {}) as CacheMetadata;
+  }
+
+  private async dropCacheMetadata(repoData: RepoRemoteInputData) {
+    return this._storageHandlerJsonCache.emptyStoreData(this.getMetadataFileName(repoData));
   }
 
   private getPolicyFileName(repoData: RepoRemoteInputData) {

--- a/packages/synchronizer/src/utils/synchronizer.ts
+++ b/packages/synchronizer/src/utils/synchronizer.ts
@@ -33,16 +33,6 @@ export type ProjectInfo = {
   slug: string;
 };
 
-export type ProjectRepoInputData = {
-  repoData: RepoRemoteInputData;
-  ownerProjectSlug: string;
-};
-
-export type ProjectRepoPathData = {
-  repoPath: string;
-  ownerProjectSlug: string;
-};
-
 export class Synchronizer extends EventEmitter {
   private _pullPromise: Promise<PolicyData> | undefined;
   private _projectDataCache: Record<string, ApiUserProject> = {};
@@ -99,31 +89,6 @@ export class Synchronizer extends EventEmitter {
           name: freshProjectInfo.name,
           slug: freshProjectInfo.slug,
         };
-  }
-
-  async getProjectRepoDetails(projectRepoPath: ProjectRepoPathData, tokenInfo: TokenInfo): Promise<any>;
-  async getProjectRepoDetails(projectRepoData: ProjectRepoInputData, tokenInfo: TokenInfo): Promise<any>;
-  async getProjectRepoDetails(
-    projectRepoPathOrData: ProjectRepoPathData | ProjectRepoInputData,
-    tokenInfo: TokenInfo
-  ) {
-    if (!tokenInfo || tokenInfo?.accessToken?.length === 0) {
-      throw new Error('Cannot fetch without access token.');
-    }
-
-    let projectRepoInput = projectRepoPathOrData as ProjectRepoInputData;
-    if (this.isProjectRepoPath(projectRepoPathOrData)) {
-      projectRepoInput = await this.getProjectRepoData(projectRepoPathOrData as ProjectRepoPathData);
-    }
-
-    const response = await this._apiHandler.getProjectDetails({
-      slug: projectRepoInput.ownerProjectSlug,
-      owner: projectRepoInput.repoData.owner,
-      name: projectRepoInput.repoData.name,
-      provider: projectRepoInput.repoData.provider,
-    }, tokenInfo);
-
-    return response?.data?.getProject;
   }
 
   async getPolicy(rootPath: string, forceRefetch?: boolean, tokenInfo?: TokenInfo): Promise<PolicyData>;
@@ -487,14 +452,6 @@ export class Synchronizer extends EventEmitter {
     return typeof inputData === 'string' ? await this.getRootGitData(inputData) : (inputData as RepoRemoteData);
   }
 
-  private async getProjectRepoData(repoProjectPath: ProjectRepoPathData): Promise<ProjectRepoInputData> {
-    const gitData = await this.getRootGitData(repoProjectPath.repoPath);
-    return {
-      repoData: gitData,
-      ownerProjectSlug: repoProjectPath.ownerProjectSlug,
-    };
-  }
-
   private isProjectData(projectData: any) {
     return Object.keys(projectData).length === 1 && projectData.slug;
   }
@@ -507,9 +464,5 @@ export class Synchronizer extends EventEmitter {
     return this.isProjectData(input) || input.ownerProjectSlug?.length > 0
       ? input.slug ?? input.ownerProjectSlug
       : undefined;
-  }
-
-  private isProjectRepoPath(repoData: any) {
-    return Object.keys(repoData).length === 2 && repoData.repoPath;
   }
 }

--- a/packages/synchronizer/src/utils/synchronizer.ts
+++ b/packages/synchronizer/src/utils/synchronizer.ts
@@ -33,6 +33,9 @@ export type ProjectInfo = {
   slug: string;
 };
 
+/**
+ * @deprecated ProjectSynchronizer should be used instead if possible.
+ */
 export class Synchronizer extends EventEmitter {
   private _pullPromise: Promise<PolicyData> | undefined;
   private _projectDataCache: Record<string, ApiUserProject> = {};

--- a/packages/synchronizer/src/utils/synchronizer.ts
+++ b/packages/synchronizer/src/utils/synchronizer.ts
@@ -33,6 +33,16 @@ export type ProjectInfo = {
   slug: string;
 };
 
+export type ProjectRepoInputData = {
+  repoData: RepoRemoteInputData;
+  ownerProjectSlug: string;
+};
+
+export type ProjectRepoPathData = {
+  repoPath: string;
+  ownerProjectSlug: string;
+};
+
 export class Synchronizer extends EventEmitter {
   private _pullPromise: Promise<PolicyData> | undefined;
   private _projectDataCache: Record<string, ApiUserProject> = {};
@@ -89,6 +99,31 @@ export class Synchronizer extends EventEmitter {
           name: freshProjectInfo.name,
           slug: freshProjectInfo.slug,
         };
+  }
+
+  async getProjectRepoDetails(projectRepoPath: ProjectRepoPathData, tokenInfo: TokenInfo): Promise<any>;
+  async getProjectRepoDetails(projectRepoData: ProjectRepoInputData, tokenInfo: TokenInfo): Promise<any>;
+  async getProjectRepoDetails(
+    projectRepoPathOrData: ProjectRepoPathData | ProjectRepoInputData,
+    tokenInfo: TokenInfo
+  ) {
+    if (!tokenInfo || tokenInfo?.accessToken?.length === 0) {
+      throw new Error('Cannot fetch without access token.');
+    }
+
+    let projectRepoInput = projectRepoPathOrData as ProjectRepoInputData;
+    if (this.isProjectRepoPath(projectRepoPathOrData)) {
+      projectRepoInput = await this.getProjectRepoData(projectRepoPathOrData as ProjectRepoPathData);
+    }
+
+    const response = await this._apiHandler.getProjectDetails({
+      slug: projectRepoInput.ownerProjectSlug,
+      owner: projectRepoInput.repoData.owner,
+      name: projectRepoInput.repoData.name,
+      provider: projectRepoInput.repoData.provider,
+    }, tokenInfo);
+
+    return response?.data?.getProject;
   }
 
   async getPolicy(rootPath: string, forceRefetch?: boolean, tokenInfo?: TokenInfo): Promise<PolicyData>;
@@ -452,6 +487,14 @@ export class Synchronizer extends EventEmitter {
     return typeof inputData === 'string' ? await this.getRootGitData(inputData) : (inputData as RepoRemoteData);
   }
 
+  private async getProjectRepoData(repoProjectPath: ProjectRepoPathData): Promise<ProjectRepoInputData> {
+    const gitData = await this.getRootGitData(repoProjectPath.repoPath);
+    return {
+      repoData: gitData,
+      ownerProjectSlug: repoProjectPath.ownerProjectSlug,
+    };
+  }
+
   private isProjectData(projectData: any) {
     return Object.keys(projectData).length === 1 && projectData.slug;
   }
@@ -464,5 +507,9 @@ export class Synchronizer extends EventEmitter {
     return this.isProjectData(input) || input.ownerProjectSlug?.length > 0
       ? input.slug ?? input.ownerProjectSlug
       : undefined;
+  }
+
+  private isProjectRepoPath(repoData: any) {
+    return Object.keys(repoData).length === 2 && repoData.repoPath;
   }
 }


### PR DESCRIPTION
This PR is a part of https://github.com/kubeshop/vscode-monokle/issues/93.

The main goal is to allow fetching all data required for integrations at once and to allow fetched data to be used in synchronous manner.

I kept previous `synchronizer` without changes (but deprecated it) since it is used by multiple integrations. And introduced `ProjectSynchronizer` since the way it works is quite different from the previous one. Putting everything in the same class would be a mess.

The main idea is that it exposes `synchronize` method (the same as previous one) which refetches data whenever called (so this is integrator responsibility to know when to refetch). Entire response is cached and then used when `get*` methods are used. This way fetching is decoupled from getting/using data.

## Changes

- Introduced `ProjectSynchronizer`.
- Introduced `getPermissions` query in `ApiHandler` which may be useful too for other integrations.

## Fixes

- None.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
