### PR TITLE
Allow passing suppression location

### DIFF
--- a/.changeset/blue-donkeys-sparkle.md
+++ b/.changeset/blue-donkeys-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@monokle/synchronizer": patch
+---
+
+Suppression location can now be passed 'toggleSuppression' API

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -168,7 +168,7 @@ const getRepoIdQuery = `
 const toggleSuppressionMutation = `
   mutation toggleSuppression($fingerprint: String!, $repoId: ID!, $description: String!, $location: String) {
     toggleSuppression(
-      input: {fingerprint: $fingerprint, repository: $repoId, description: $description, $location: location, skipReview: true}
+      input: {fingerprint: $fingerprint, repository: $repoId, description: $description, location: $location, skipReview: true}
     ) {
       id
       fingerprint

--- a/packages/synchronizer/src/handlers/apiHandler.ts
+++ b/packages/synchronizer/src/handlers/apiHandler.ts
@@ -166,9 +166,9 @@ const getRepoIdQuery = `
 `;
 
 const toggleSuppressionMutation = `
-  mutation toggleSuppression($fingerprint: String!, $repoId: ID!, $description: String!) {
+  mutation toggleSuppression($fingerprint: String!, $repoId: ID!, $description: String!, $location: String) {
     toggleSuppression(
-      input: {fingerprint: $fingerprint, repository: $repoId, description: $description, skipReview: true}
+      input: {fingerprint: $fingerprint, repository: $repoId, description: $description, $location: location, skipReview: true}
     ) {
       id
       fingerprint
@@ -243,7 +243,7 @@ export type ApiSuppression = {
   id: string;
   fingerprint: string;
   description: string;
-  locations: string;
+  location: string;
   status: SuppressionStatus;
   justification: string;
   expiresAt: string;
@@ -402,8 +402,8 @@ export class ApiHandler {
     return this.queryApi(getRepoIdQuery, tokenInfo, {projectSlug, repoOwner, repoName});
   }
 
-  async toggleSuppression(fingerprint: string, repoId: string, description: string, tokenInfo: TokenInfo) {
-    return this.queryApi<ApiSuppressionsData>(toggleSuppressionMutation, tokenInfo, {fingerprint, repoId, description});
+  async toggleSuppression(fingerprint: string, repoId: string, description: string, location: string | undefined, tokenInfo: TokenInfo) {
+    return this.queryApi<ApiSuppressionsData>(toggleSuppressionMutation, tokenInfo, {fingerprint, repoId, description, location});
   }
 
   generateDeepLink(path: string) {

--- a/packages/synchronizer/src/utils/projectSynchronizer.ts
+++ b/packages/synchronizer/src/utils/projectSynchronizer.ts
@@ -78,7 +78,7 @@ export class ProjectSynchronizer extends EventEmitter {
     return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.suppressions ?? [];
   }
 
-  async toggleSuppression(tokenInfo: TokenInfo, fingerprint: string, description: string, rootPath: string, projectSlug?: string) {
+  async toggleSuppression(tokenInfo: TokenInfo, fingerprint: string, description: string, location: string, rootPath: string, projectSlug?: string) {
     if (!tokenInfo?.accessToken?.length) {
       throw new Error('Cannot use suppressions without access token.');
     }
@@ -105,7 +105,7 @@ export class ProjectSynchronizer extends EventEmitter {
       throw new Error('Cannot suppress due to missing repository id or project slug!');
     }
 
-    const suppressionResult = await this._apiHandler.toggleSuppression(fingerprint, id, description, tokenInfo);
+    const suppressionResult = await this._apiHandler.toggleSuppression(fingerprint, id, description, location, tokenInfo);
     if (suppressionResult?.data?.getSuppressions?.data?.length) {
         const existingSuppressions = await this.readSuppressions(repoData);
         const allSuppressions = this.mergeSuppressions(existingSuppressions, suppressionResult.data.getSuppressions.data);

--- a/packages/synchronizer/src/utils/projectSynchronizer.ts
+++ b/packages/synchronizer/src/utils/projectSynchronizer.ts
@@ -78,7 +78,7 @@ export class ProjectSynchronizer extends EventEmitter {
     return this._dataCache[this.getCacheId(rootPath, projectSlug)]?.suppressions ?? [];
   }
 
-  async toggleSuppression(tokenInfo: TokenInfo, fingerprint: string, description: string, location: string, rootPath: string, projectSlug?: string) {
+  async toggleSuppression(tokenInfo: TokenInfo, fingerprint: string, description: string, location: string | undefined, rootPath: string, projectSlug?: string) {
     if (!tokenInfo?.accessToken?.length) {
       throw new Error('Cannot use suppressions without access token.');
     }


### PR DESCRIPTION
This PR allows passing suppression location.

This is needed only when suppression is first added (so the location is shown in Cloud UI). And subsequent edits (toggles does not require it.

## Changes

- As above.

## Fixes

- As above.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
